### PR TITLE
docs: fescueのロゴをREADMEに追加した

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+![fescue_logo_mini](https://user-images.githubusercontent.com/20200292/35912038-d45a7a86-0c3e-11e8-8b4c-d660d0d6db48.png)
+
+
 |Main|Develop|
 |:--:|:--:|
 |[![Build Status](https://travis-ci.org/Morichan/fescue.svg?branch=master)](https://travis-ci.org/Morichan/fescue)|[![Build Status](https://travis-ci.org/Morichan/fescue.svg?branch=develop)](https://travis-ci.org/Morichan/fescue)|


### PR DESCRIPTION
ロゴ作成にはiPadのMediBang Paintを利用しました。

GitHubに上げたのは25%縮小版です。