### PR TITLE
AttributeSculptorクラスの作成

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     testCompile 'org.junit.jupiter:junit-jupiter-api:5.+'
     testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.+'
     testCompile 'org.junit.jupiter:junit-jupiter-params:5.+' // parameterized tests
-    testCompile 'org.jmockit:jmockit:1.+'
+    testCompile 'org.jmockit:jmockit:1.38'
     testCompile 'org.assertj:assertj-core:3.+'
     testCompile 'net.java.quickcheck:quickcheck:0.+'
 

--- a/src/main/java/evaluation/AttributeEvaluation.java
+++ b/src/main/java/evaluation/AttributeEvaluation.java
@@ -12,12 +12,14 @@ import parser.ClassFeatureParser;
  *     AttributeEvaluation evaluation = new AttributeEvaluation();
  *     evaluation.setText("- attribute : int");
  *     evaluation.walk();
+ *
+ *     ClassFeatureParser.PropertyContext context = evaluation.getContext();
  *     // ...
  *     }
  * </pre>
  *
  * <p>
- *     最初に属性文をセットし、走査してから各項目を抽出してください。
+ *     最初に属性文をセットし、走査してからコンテキストを取得してください。
  *     順番を変えると例外として{@link IllegalArgumentException}や{@link org.antlr.v4.runtime.InputMismatchException}を投げます。
  * </p>
  */
@@ -42,7 +44,8 @@ public class AttributeEvaluation extends FeatureEvaluation {
      *     詳しくは{@link #insertSpaceBothEndsOfRangeOperator(String)}を参照してください。
      * </p>
      *
-     * @param text 設定する属性文 {@code null}不可（{@link #insertSpaceBothEndsOfRangeOperator(String)}で{@link IllegalArgumentException}を投げる。）
+     * @param text 設定する属性文 <br>
+     *     {@code null}不可（{@link #insertSpaceBothEndsOfRangeOperator(String)}で{@link IllegalArgumentException}を投げます。）
      */
     @Override
     public void setText(String text) {
@@ -56,7 +59,7 @@ public class AttributeEvaluation extends FeatureEvaluation {
      *     {@link #setText(String)}を実行する前にこのメソッドを実行した場合は{@link IllegalStateException}を投げます。
      * </p>
      *
-     * @return 属性文 {@code null}なし
+     * @return 属性文 <br> {@code null}なし
      */
     @Override
     public String getText() {
@@ -68,10 +71,6 @@ public class AttributeEvaluation extends FeatureEvaluation {
 
     /**
      * <p> 字句解析と構文解析を行い、構文解析木を走査します。 </p>
-     *
-     * <p>
-     *     属性文を設定していない場合は{@link IllegalArgumentException}を投げます。
-     * </p>
      *
      * <p>
      *     次の場合は例外を投げます。

--- a/src/main/java/evaluation/AttributeEvaluation.java
+++ b/src/main/java/evaluation/AttributeEvaluation.java
@@ -1,0 +1,137 @@
+package evaluation;
+
+import parser.ClassFeatureParser;
+
+/**
+ * <p> 属性における要素の評価クラス </p>
+ *
+ * <p> 簡単な使い方を次に示します。</p>
+ *
+ * <pre>
+ *     {@code
+ *     AttributeEvaluation evaluation = new AttributeEvaluation();
+ *     evaluation.setText("- attribute : int");
+ *     evaluation.walk();
+ *     // ...
+ *     }
+ * </pre>
+ *
+ * <p>
+ *     最初に属性文をセットし、走査してから各項目を抽出してください。
+ *     順番を変えると例外として{@link IllegalArgumentException}や{@link org.antlr.v4.runtime.InputMismatchException}を投げます。
+ * </p>
+ */
+public class AttributeEvaluation extends FeatureEvaluation {
+
+    /**
+     * 属性文コンテキスト
+     */
+    private ClassFeatureParser.PropertyContext context;
+
+    /**
+     * 属性文
+     */
+    private String attribute;
+
+    /**
+     * <p> 属性文を設定します。 </p>
+     *
+     * <p>
+     *     {@code "\\.\\."}という文字列（2つ連続したドット）が存在した場合、その両端に半角スペースを挿入します。
+     *     これは、多重度における下限と上限の指定の箇所をパースする際に、ANTLR4の仕様により半角スペースが入っていない場合はうまくパースできないためです。
+     *     詳しくは{@link #insertSpaceBothEndsOfRangeOperator(String)}を参照してください。
+     * </p>
+     *
+     * @param text 設定する属性文 {@code null}不可（{@link #insertSpaceBothEndsOfRangeOperator(String)}で{@link IllegalArgumentException}を投げる。）
+     */
+    @Override
+    public void setText(String text) {
+        attribute = insertSpaceBothEndsOfRangeOperator(text);
+    }
+
+    /**
+     * <p> 属性文を取得します。 </p>
+     *
+     * <p>
+     *     {@link #setText(String)}を実行する前にこのメソッドを実行した場合は{@link IllegalStateException}を投げます。
+     * </p>
+     *
+     * @return 属性文 {@code null}なし
+     */
+    @Override
+    public String getText() {
+        if (attribute == null) throw new IllegalStateException();
+        return attribute;
+    }
+
+
+
+    /**
+     * <p> 字句解析と構文解析を行い、構文解析木を走査します。 </p>
+     *
+     * <p>
+     *     属性文を設定していない場合は{@link IllegalArgumentException}を投げます。
+     * </p>
+     *
+     * <p>
+     *     次の場合は例外を投げます。
+     * </p>
+     *
+     * <ul>
+     *     <li>属性文を設定していない場合（{@link #setText(String)}参照） : {@link IllegalArgumentException}</li>
+     *     <li>設定した属性文が予約語と同じ文字列の場合 : {@link ClassFeatureParser.PropertyContext#exception}</li>
+     * </ul>
+     */
+    @Override
+    public void walk() {
+        initIfIsSameBetweenNameAndKeyword();
+        if (attribute == null) throw new IllegalArgumentException();
+
+        ClassFeatureParser parser = generateParser(attribute);
+        FeatureEvalListener listener = walk(parser.property());
+        context = listener.getProperty();
+
+        confirmExtractingName();
+    }
+
+    /**
+     * <p> 字句解析および構文解析結果のコンテキストを取得します。 </p>
+     *
+     * <p>
+     *     {@link #walk()}を実行する前にこのメソッドを実行すると{@link IllegalStateException}を投げます。
+     * </p>
+     *
+     * @return 字句解析および構文解析結果のコンテキスト
+     */
+    public ClassFeatureParser.PropertyContext getContext() {
+        if (context == null) throw new IllegalStateException();
+        return context;
+    }
+
+
+
+    /**
+     * <p> 属性名が抽出できるかどうか確認します。 </p>
+     *
+     * <p>
+     *     次の場合は例外を投げます。
+     * </p>
+     *
+     * <ul>
+     *     <li>属性文を設定していない場合（{@link #setText(String)}参照） : {@link IllegalArgumentException}</li>
+     *     <li>設定した属性文が予約語と同じ文字列の場合 : {@link ClassFeatureParser.PropertyContext#exception}</li>
+     * </ul>
+     */
+    private void confirmExtractingName() {
+        String name = null;
+
+        for (int i = 0; i < context.getChildCount(); i++) {
+            if (context.getChild(i) instanceof ClassFeatureParser.NameContext) {
+                name = context.getChild(i).getText();
+                break;
+            }
+            if (context.exception != null) throw context.exception;
+        }
+        if (name == null) throw new IllegalArgumentException();
+    }
+}

--- a/src/main/java/evaluation/Evaluation.java
+++ b/src/main/java/evaluation/Evaluation.java
@@ -1,7 +1,7 @@
 package evaluation;
 
 /**
- * 抽出クラスインタフェース
+ * 評価クラスインタフェース
  */
 public interface Evaluation {
     /**

--- a/src/main/java/evaluation/FeatureEvalListener.java
+++ b/src/main/java/evaluation/FeatureEvalListener.java
@@ -5,9 +5,11 @@ import org.antlr.v4.runtime.tree.ParseTreeListener;
 import parser.ClassFeatureParser;
 
 /**
- * 構文解析木の走査クラス
+ * <p> 構文解析木の評価クラス </p>
  *
- * {@link parser.ClassFeatureBaseListener}およびそのクラスを自動生成するANTLRに依存します。
+ * <p>
+ *     {@link parser.ClassFeatureBaseListener}およびそのクラスを自動生成するANTLRに依存します。
+ * </p>
  */
 public class FeatureEvalListener extends parser.ClassFeatureBaseListener {
     /**
@@ -54,7 +56,7 @@ public class FeatureEvalListener extends parser.ClassFeatureBaseListener {
      * 属性文コンテキストを取得します。
      * {@link #enterProperty(ClassFeatureParser.PropertyContext)}が実行されなかった場合は{@code null}を返します。
      *
-     * @return 属性文コンテキスト {@code null}の可能性あり
+     * @return 属性文コンテキスト <br> {@code null}の可能性あり
      */
     public ClassFeatureParser.PropertyContext getProperty() {
         return property;
@@ -64,7 +66,7 @@ public class FeatureEvalListener extends parser.ClassFeatureBaseListener {
      * 操作文コンテキストを取得します。
      * {@link #enterOperation(ClassFeatureParser.OperationContext)}が実行されなかった場合は{@code null}を返します。
      *
-     * @return 操作文コンテキスト {@code null}の可能性あり
+     * @return 操作文コンテキスト <br> {@code null}の可能性あり
      */
     public ClassFeatureParser.OperationContext getOperation() {
         return operation;

--- a/src/main/java/evaluation/FeatureEvaluation.java
+++ b/src/main/java/evaluation/FeatureEvaluation.java
@@ -12,7 +12,12 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * クラスの属性または操作の抽象クラス
+ * <p> クラスの属性文または操作文の評価クラス </p>
+ *
+ * <p>
+ *     抽象クラスですが、このクラス内で定義している抽象メソッドはありません。
+ *     このクラスを実装する場合は、Evaluationインタフェースで定義している抽象メソッドを実装してください。
+ * </p>
  */
 abstract public class FeatureEvaluation implements Evaluation {
 
@@ -22,8 +27,11 @@ abstract public class FeatureEvaluation implements Evaluation {
     private boolean isSameBetweenNameAndKeyword = false;
 
     /**
-     * {@link ClassFeatureParser.PropertiesContext#exception}または{@link ClassFeatureParser.OperationContext#exception}が持つ{@link InputMismatchException}インスタンス
-     * もし持っていない場合は{@code null}を持つ
+     * <p> {@link ClassFeatureParser.PropertiesContext#exception}または{@link ClassFeatureParser.OperationContext#exception}が持つ{@link InputMismatchException}インスタンス </p>
+     *
+     * <p>
+     *     もし持っていない場合は{@code null}を持ちます。
+     * </p>
      */
     private InputMismatchException inputMismatchException;
 

--- a/src/main/java/feature/value/expression/Identifier.java
+++ b/src/main/java/feature/value/expression/Identifier.java
@@ -1,5 +1,7 @@
 package feature.value.expression;
 
+import javafx.css.Match;
+
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -29,6 +31,7 @@ public class Identifier {
 
     private Pattern stringEnclosedBySingleQuotation = Pattern.compile("^'(.)*'$");
     private Pattern stringEnclosedByDoubleQuotation = Pattern.compile("^\"(.)*\"$");
+    private Pattern decimalLiteralString = Pattern.compile("(0|[1-9](\\.?|_\\.))[lL]?");
 
     /**
      * <p> デフォルトコンストラクタ </p>
@@ -144,7 +147,8 @@ public class Identifier {
     boolean isValue(String text) {
         Matcher singleQuotationMatcher = stringEnclosedBySingleQuotation.matcher(text);
         Matcher doubleQuotationMatcher = stringEnclosedByDoubleQuotation.matcher(text);
+        Matcher decimalLiteralMatcher = decimalLiteralString.matcher(text);
 
-        return singleQuotationMatcher.matches() || doubleQuotationMatcher.matches();
+        return singleQuotationMatcher.matches() || doubleQuotationMatcher.matches() || decimalLiteralMatcher.matches();
     }
 }

--- a/src/main/java/feature/value/expression/MethodCall.java
+++ b/src/main/java/feature/value/expression/MethodCall.java
@@ -42,6 +42,14 @@ public class MethodCall implements Expression {
      * @param expressions メソッド引数（0こ以上の複数を設定可能）<br>{@code null}不可
      */
     public MethodCall(String text, Expression... expressions) {
+        initMethodCall(text, expressions);
+    }
+
+    public MethodCall(String text, List<Expression> expressions) {
+        initMethodCall(text, expressions.toArray(new Expression[expressions.size()]));
+    }
+
+    private void initMethodCall(String text, Expression... expressions) {
         for (Expression exp : expressions)
             if (exp == null)
                 throw new IllegalArgumentException();

--- a/src/main/java/feature/value/expression/symbol/Symbol.java
+++ b/src/main/java/feature/value/expression/symbol/Symbol.java
@@ -106,4 +106,18 @@ abstract public class Symbol {
         if (symbolText == null || !string2symbol.containsKey(symbolText)) throw new IllegalStateException();
         return string2symbol.get(symbolText);
     }
+
+    /**
+     * <p> 文字列が演算子として存在する場合は真を返す真偽値判定を行います。 </p>
+     *
+     * <p>
+     *     {@code ""}（空文字）および{@code null}を入力した場合は偽を返します。
+     * </p>
+     *
+     * @param symbolText 演算子の文字列 <br> {@code ""}（空文字）および{@code null}可
+     * @return 演算子として存在する場合は真を返す真偽値 <br> {@code ""}（空文字）および{@code null} の場合は偽を返します。
+     */
+    static public boolean isIncluded(String symbolText) {
+        return string2symbol.containsKey(symbolText);
+    }
 }

--- a/src/main/java/sculptor/AttributeSculptor.java
+++ b/src/main/java/sculptor/AttributeSculptor.java
@@ -1,6 +1,8 @@
 package sculptor;
 
 import evaluation.AttributeEvaluation;
+import feature.Attribute;
+import feature.name.Name;
 import org.antlr.v4.runtime.ParserRuleContext;
 import parser.ClassFeatureParser;
 
@@ -49,5 +51,18 @@ public class AttributeSculptor {
     public ParserRuleContext getContext() {
         if (attribute == null) throw new IllegalStateException();
         return attribute;
+    }
+
+    public Attribute carve() {
+        Attribute feature = new Attribute(new Name("attribute"));
+
+        for (int i = 0; i < attribute.getChildCount(); i++) {
+            if (attribute.getChild(i) instanceof ClassFeatureParser.NameContext) {
+                feature.setName(new Name(attribute.getChild(i).getText()));
+                break;
+            }
+        }
+
+        return feature;
     }
 }

--- a/src/main/java/sculptor/AttributeSculptor.java
+++ b/src/main/java/sculptor/AttributeSculptor.java
@@ -1,0 +1,53 @@
+package sculptor;
+
+import evaluation.AttributeEvaluation;
+import org.antlr.v4.runtime.ParserRuleContext;
+import parser.ClassFeatureParser;
+
+/**
+ * <p> 属性彫刻家 </p>
+ *
+ * <p>
+ *     属性文を入力することで、{@link feature.Attribute}クラスのインスタンス化を行います。
+ * </p>
+ */
+public class AttributeSculptor {
+
+    private AttributeEvaluation evaluation;
+    private ClassFeatureParser.PropertyContext attribute;
+
+    /**
+     * <p> 構文解析を行う。 </p>
+     *
+     * <p>
+     *     属性文を入力すると構文解析を行います。
+     *     ここでいう構文解析とは、字句解析と構文解析を含みます。
+     * </p>
+     *
+     * @param attributeText 属性文 <br> {@code null}不可
+     */
+    public void parse(String attributeText) {
+        if (attributeText == null) throw new IllegalArgumentException();
+
+        evaluation = new AttributeEvaluation();
+        evaluation.setText(attributeText);
+        evaluation.walk();
+
+        attribute = evaluation.getContext();
+    }
+
+    /**
+     * <p> 属性文コンテキストを取得します。 </p>
+     *
+     * <p>
+     *     コンテキストを取得したい場合はこのメソッドを利用してください。
+     *     テストコード以外ではあまり使わないと思います。
+     * </p>
+     *
+     * @return 属性文コンテキスト
+     */
+    public ParserRuleContext getContext() {
+        if (attribute == null) throw new IllegalStateException();
+        return attribute;
+    }
+}

--- a/src/main/java/sculptor/AttributeSculptor.java
+++ b/src/main/java/sculptor/AttributeSculptor.java
@@ -130,26 +130,38 @@ public class AttributeSculptor {
             if (Symbol.isIncluded(ctx.getChild(0).getText())) {
                 expression = new Monomial(ctx.getChild(0).getText(),
                         createExpression((ClassFeatureParser.ExpressionContext) ctx.getChild(1)));
-            // } else if (ctx.getChild(0).getClass() == ClassFeatureParser.ExpressionContext.class) {
-            } else {
-                expression = new MethodCall(ctx.getChild(0).getText(),
-                        extractExpressionsFromArguments((ClassFeatureParser.ArgumentsContext) ctx.getChild(1)));
+            } else { // if (ctx.getChild(0).getClass() == ClassFeatureParser.ExpressionContext.class) {
+                if (ctx.getChild(0).getChildCount() == 1) {
+                    expression = new MethodCall(ctx.getChild(0).getText(),
+                            extractExpressionsFromArguments((ClassFeatureParser.ArgumentsContext) ctx.getChild(1)));
+                } else {
+                    List<Expression> expressions = new ArrayList<>();
+                    if (ctx.getChild(1).getChildCount() >= 3) {
+                        for (int i = 0; i < ctx.getChild(1).getChild(1).getChildCount(); i += 2) {
+                            expressions.add(createExpression((ClassFeatureParser.ExpressionContext) ctx.getChild(1).getChild(1).getChild(i)));
+                        }
+                    }
+                    expression = new Binomial(ctx.getChild(0).getChild(1).getText(),
+                            createExpression((ClassFeatureParser.ExpressionContext) ctx.getChild(0).getChild(0)),
+                            new MethodCall(ctx.getChild(0).getChild(2).getText(), expressions));
+                }
             }
 
         } else {
             if (ctx.getChild(1).getClass() == ClassFeatureParser.ExpressionContext.class) {
                 expression = new ExpressionWithParen(createExpression((ClassFeatureParser.ExpressionContext) ctx.getChild(1)));
             } else if (ctx.getChild(1).getText().equals(".")) {
-                if (ctx.getChild(2).getClass() == ClassFeatureParser.ExplicitGenericInvocationSuffixContext.class) {
-                    expression = new Binomial(ctx.getChild(1).getText(),
-                            createExpression((ClassFeatureParser.ExpressionContext) ctx.getChild(0)),
-                            new MethodCall(ctx.getChild(2).getChild(0).getText(),
-                                    extractExpressionsFromArguments((ClassFeatureParser.ArgumentsContext) ctx.getChild(2).getChild(1))));
-                } else {
+                // ANTLR文法ファイル上ではここに入るはずだが決して入ることはない
+                // if (ctx.getChild(2).getClass() == ClassFeatureParser.ExplicitGenericInvocationSuffixContext.class) {
+                //     expression = new Binomial(ctx.getChild(1).getText(),
+                //             createExpression((ClassFeatureParser.ExpressionContext) ctx.getChild(0)),
+                //             new MethodCall(ctx.getChild(2).getChild(0).getText(),
+                //                     extractExpressionsFromArguments((ClassFeatureParser.ArgumentsContext) ctx.getChild(2).getChild(1))));
+                // } else {
                     expression = new Binomial(ctx.getChild(1).getText(),
                             createExpression((ClassFeatureParser.ExpressionContext) ctx.getChild(0)),
                             new OneIdentifier(ctx.getChild(2).getText()));
-                }
+                // }
             } else {
                 expression = new Binomial(ctx.getChild(1).getText(),
                         createExpression((ClassFeatureParser.ExpressionContext) ctx.getChild(0)),

--- a/src/test/java/evaluation/AttributeEvaluationTest.java
+++ b/src/test/java/evaluation/AttributeEvaluationTest.java
@@ -1,0 +1,93 @@
+package evaluation;
+
+import org.antlr.v4.runtime.InputMismatchException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import parser.ClassFeatureParser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+class AttributeEvaluationTest {
+    AttributeEvaluation obj;
+
+    @Nested
+    class 正しい文を入力している場合 {
+
+        @BeforeEach
+        void setup() {
+            obj = new AttributeEvaluation();
+        }
+
+        @Test
+        void 文を設定すると文を返す() {
+            String expected = "attribute";
+
+            obj.setText(expected);
+            String actual = obj.getText();
+
+            assertThat(actual).isEqualTo(expected);
+        }
+
+        @Test
+        void 文を設定して走査するとエラーを返さない() {
+            String expected = "attribute";
+            String actual;
+
+            obj.setText("attribute");
+            obj.walk();
+            actual = obj.getText();
+
+            assertThat(actual).isEqualTo(expected);
+        }
+
+        @Test
+        void 文を設定して走査するとコンテキストを返す() {
+            ClassFeatureParser.PropertyContext actual;
+
+            obj.setText("attribute");
+            obj.walk();
+            actual = obj.getContext();
+
+            assertThat(actual).isInstanceOf(ClassFeatureParser.PropertyContext.class);
+        }
+    }
+
+    @Nested
+    class 正しい文を入力していない場合 {
+
+        @Test
+        void 文を設定せずに走査したらエラーを返す() {
+            obj = new AttributeEvaluation();
+
+            assertThatThrownBy(() -> obj.walk()).isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        void 文を設定せずに文を取得しようとしたら例外を投げる() {
+            obj = new AttributeEvaluation();
+
+            assertThatThrownBy(() -> obj.getText()).isInstanceOf(IllegalStateException.class);
+        }
+
+        @Test
+        void 正しくない文を設定して走査したらエラーを返す() {
+            obj = new AttributeEvaluation();
+
+            obj.setText("- int");
+
+            assertThatThrownBy(() -> obj.walk()).isInstanceOf(InputMismatchException.class);
+        }
+
+        @Test
+        void 文を設定せずにコンテキストを取得しようとすると例外を投げる() {
+            obj = new AttributeEvaluation();
+
+            obj.setText("attribute");
+
+            assertThatThrownBy(() -> obj.getContext()).isInstanceOf(IllegalStateException.class);
+        }
+    }
+}

--- a/src/test/java/evaluation/AttributeEvaluationTest.java
+++ b/src/test/java/evaluation/AttributeEvaluationTest.java
@@ -47,7 +47,7 @@ class AttributeEvaluationTest {
         void 文を設定して走査するとコンテキストを返す() {
             ClassFeatureParser.PropertyContext actual;
 
-            obj.setText("attribute");
+            obj.setText("- /attribute");
             obj.walk();
             actual = obj.getContext();
 

--- a/src/test/java/feature/value/expression/IdentifierTest.java
+++ b/src/test/java/feature/value/expression/IdentifierTest.java
@@ -60,6 +60,15 @@ class IdentifierTest {
         }
 
         @Test
+        void 数値のみの文字列を入力すると文字列を返す() {
+            String expected = "1";
+
+            obj.set("1");
+
+            assertThat(obj).hasToString(expected);
+        }
+
+        @Test
         void ダブルクオーテーションで囲んだ文字列を入力すると文字列を返す() {
             String expected = "\"stringName\"";
 
@@ -93,6 +102,14 @@ class IdentifierTest {
             obj.set("''");
 
             assertThat(obj).hasToString(expected);
+        }
+
+        @Test
+        void 数値のみの文字列は値である() {
+
+            obj.set("1");
+
+            assertThat(obj.isValue()).isTrue();
         }
 
         @Test

--- a/src/test/java/feature/value/expression/MethodCallTest.java
+++ b/src/test/java/feature/value/expression/MethodCallTest.java
@@ -45,42 +45,98 @@ class MethodCallTest {
     @Nested
     class 引数を持つ場合 {
 
-        @Test
-        void メソッド名と引数を1つ入力するとメソッドを文字列で返す() {
-            String expected = "method(firstArgument)";
+        @Nested
+        class 個別に入れる際に {
 
-            obj = new MethodCall("method", new OneIdentifier("firstArgument"));
-            String actual = obj.toString();
+            @Test
+            void メソッド名と引数を1つ入力するとメソッドを文字列で返す() {
+                String expected = "method(firstArgument)";
 
-            assertThat(actual).isEqualTo(expected);
+                obj = new MethodCall("method", new OneIdentifier("firstArgument"));
+                String actual = obj.toString();
+
+                assertThat(actual).isEqualTo(expected);
+            }
+
+            @Test
+            void メソッド名と引数を2つ入力するとメソッドを文字列で返す() {
+                String expected = "method(firstArgument, secondArgument)";
+
+                obj = new MethodCall("method", new OneIdentifier("firstArgument"), new OneIdentifier("secondArgument"));
+                String actual = obj.toString();
+
+                assertThat(actual).isEqualTo(expected);
+            }
+
+            @Test
+            void メソッド名と引数を3つ入力するとメソッドを文字列で返す() {
+                String expected = "method(firstArgument, secondArgument, thirdArgument)";
+
+                obj = new MethodCall("method", new OneIdentifier("firstArgument"), new OneIdentifier("secondArgument"), new OneIdentifier("thirdArgument"));
+                String actual = obj.toString();
+
+                assertThat(actual).isEqualTo(expected);
+            }
+
+            @Test
+            void 引数に1つでもnullを含む場合は例外を投げる() {
+                assertThatThrownBy(() ->
+                        obj = new MethodCall("method",
+                                new OneIdentifier("firstArgument"), new OneIdentifier("secondArgument"), null))
+                        .isInstanceOf(IllegalArgumentException.class);
+            }
         }
 
-        @Test
-        void メソッド名と引数を2つ入力するとメソッドを文字列で返す() {
-            String expected = "method(firstArgument, secondArgument)";
+        @Nested
+        class Listインスタンスとして入れる際に {
 
-            obj = new MethodCall("method", new OneIdentifier("firstArgument"), new OneIdentifier("secondArgument"));
-            String actual = obj.toString();
+            @Test
+            void メソッド名と引数を1つ入力するとメソッドを文字列で返す() {
+                String expected = "method(firstArgument)";
+                List<Expression> oneExpression = Arrays.asList(new OneIdentifier("firstArgument"));
 
-            assertThat(actual).isEqualTo(expected);
-        }
+                obj = new MethodCall("method", oneExpression);
+                String actual = obj.toString();
 
-        @Test
-        void メソッド名と引数を3つ入力するとメソッドを文字列で返す() {
-            String expected = "method(firstArgument, secondArgument, thirdArgument)";
+                assertThat(actual).isEqualTo(expected);
+            }
 
-            obj = new MethodCall("method", new OneIdentifier("firstArgument"), new OneIdentifier("secondArgument"), new OneIdentifier("thirdArgument"));
-            String actual = obj.toString();
+            @Test
+            void メソッド名と引数を2つ入力するとメソッドを文字列で返す() {
+                String expected = "method(firstArgument, secondArgument)";
+                List<Expression> twoExpression = Arrays.asList(
+                        new OneIdentifier("firstArgument"), new OneIdentifier("secondArgument"));
 
-            assertThat(actual).isEqualTo(expected);
-        }
+                obj = new MethodCall("method", twoExpression);
+                String actual = obj.toString();
 
-        @Test
-        void 引数に1つでもnullを含む場合は例外を投げる() {
-            assertThatThrownBy(() ->
-                    obj = new MethodCall("method",
-                            new OneIdentifier("firstArgument"), new OneIdentifier("secondArgument"), null))
-                    .isInstanceOf(IllegalArgumentException.class);
+                assertThat(actual).isEqualTo(expected);
+            }
+
+            @Test
+            void メソッド名と引数を3つ入力するとメソッドを文字列で返す() {
+                String expected = "method(firstArgument, secondArgument, thirdArgument)";
+                List<Expression> threeExpression = Arrays.asList(
+                        new OneIdentifier("firstArgument"),
+                        new OneIdentifier("secondArgument"),
+                        new OneIdentifier("thirdArgument"));
+
+                obj = new MethodCall("method",threeExpression);
+                String actual = obj.toString();
+
+                assertThat(actual).isEqualTo(expected);
+            }
+
+            @Test
+            void 引数に1つでもnullを含む場合は例外を投げる() {
+                assertThatThrownBy(() ->
+                        obj = new MethodCall("method",
+                                Arrays.asList(
+                                        new OneIdentifier("firstArgument"),
+                                        new OneIdentifier("secondArgument"),
+                                        null)))
+                        .isInstanceOf(IllegalArgumentException.class);
+            }
         }
     }
 

--- a/src/test/java/feature/value/expression/symbol/SymbolTest.java
+++ b/src/test/java/feature/value/expression/symbol/SymbolTest.java
@@ -94,6 +94,14 @@ class SymbolTest {
 
             assertThat(actual.isHadSpaceBothSides()).isEqualTo(expected);
         }
+
+        @RepeatedTest(symbolCount)
+        void 存在する演算子を入力すると真を返す(RepetitionInfo info) {
+
+            boolean actual = Symbol.isIncluded(symbolStrings.get(info.getCurrentRepetition() - 1));
+
+            assertThat(actual).isTrue();
+        }
     }
 
     @Nested
@@ -107,6 +115,30 @@ class SymbolTest {
         @Test
         void 演算子の選択にnullを入力すると例外を投げる() {
             assertThatThrownBy(() -> Symbol.choose(null)).isInstanceOf(IllegalStateException.class);
+        }
+
+        @Test
+        void 演算子の文字列として存在しない文字列を入れると偽を返す() {
+
+            boolean actual = Symbol.isIncluded("NotFoundText");
+
+            assertThat(actual).isFalse();
+        }
+
+        @Test
+        void 演算子の文字列として空文字を入れると偽を返す() {
+
+            boolean actual = Symbol.isIncluded("");
+
+            assertThat(actual).isFalse();
+        }
+
+        @Test
+        void 演算子の文字列としてnullを入れると偽を返す() {
+
+            boolean actual = Symbol.isIncluded(null);
+
+            assertThat(actual).isFalse();
         }
     }
 }

--- a/src/test/java/sculptor/AttributeSculptorTest.java
+++ b/src/test/java/sculptor/AttributeSculptorTest.java
@@ -251,14 +251,55 @@ class AttributeSculptorTest {
                         assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);
                     }
 
-                    @Disabled("本来は正しくない")
                     @Test
                     void インスタンスの引数のないメソッドを返す() {
                         Attribute expected = new Attribute(new Name("newNumber"));
-                        expected.setDefaultValue(new DefaultValue(
-                                        new MethodCall("instances.method")));
+                        expected.setDefaultValue(new DefaultValue(new Binomial(".",
+                                new OneIdentifier("instances"), new MethodCall("method"))));
 
-                        obj.parse("newNumber = instances . method()");
+                        obj.parse("newNumber = instances.method()");
+                        Attribute actual = obj.carve();
+
+                        assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);
+                    }
+
+                    @Test
+                    void インスタンスの引数のあるメソッドを返す() {
+                        Attribute expected = new Attribute(new Name("newNumber"));
+                        expected.setDefaultValue(new DefaultValue(new Binomial(".",
+                                new OneIdentifier("instances"), new MethodCall("method", new OneIdentifier("arg")))));
+
+                        obj.parse("newNumber = instances.method(arg)");
+                        Attribute actual = obj.carve();
+
+                        assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);
+                    }
+
+                    @Test
+                    void インスタンスの引数のあるメソッドのインスタンスを返す() {
+                        Attribute expected = new Attribute(new Name("newNumber"));
+                        expected.setDefaultValue(new DefaultValue(new Binomial(".",
+                                new Binomial(".",
+                                        new OneIdentifier("instances"),
+                                        new MethodCall("methods", new OneIdentifier("withArg"))),
+                                new OneIdentifier("instance"))));
+
+                        obj.parse("newNumber = instances.methods(withArg).instance");
+                        Attribute actual = obj.carve();
+
+                        assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);
+                    }
+
+                    @Test
+                    void インスタンスの引数のあるメソッドの引数のあるメソッドを返す() {
+                        Attribute expected = new Attribute(new Name("newNumber"));
+                        expected.setDefaultValue(new DefaultValue(new Binomial(".",
+                                new Binomial(".",
+                                        new OneIdentifier("instances"),
+                                        new MethodCall("methods", new MethodCall("withMethod"))),
+                                new MethodCall("method", new OneIdentifier("with"), new OneIdentifier("arg")))));
+
+                        obj.parse("newNumber = instances.methods(withMethod()).method(with, arg)");
                         Attribute actual = obj.carve();
 
                         assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);
@@ -275,7 +316,7 @@ class AttributeSculptorTest {
                 }
 
                 @Test
-                void 引数のないメソッドのインスタンスを返す() {
+                void 引数のないメソッドを返す() {
                     Attribute expected = new Attribute(new Name("number"));
                     expected.setDefaultValue(new DefaultValue(
                             new MethodCall("methodName")));
@@ -287,7 +328,7 @@ class AttributeSculptorTest {
                 }
 
                 @Test
-                void 引数が1つのメソッドのインスタンスを返す() {
+                void 引数が1つのメソッドを返す() {
                     Attribute expected = new Attribute(new Name("number"));
                     expected.setDefaultValue(new DefaultValue(
                             new MethodCall("methodName", new OneIdentifier(1))));
@@ -299,7 +340,7 @@ class AttributeSculptorTest {
                 }
 
                 @Test
-                void 引数が3つのメソッドのインスタンスを返す() {
+                void 引数が3つのメソッドを返す() {
                     Attribute expected = new Attribute(new Name("number"));
                     expected.setDefaultValue(new DefaultValue(
                             new MethodCall("methodName", Arrays.asList(
@@ -308,6 +349,64 @@ class AttributeSculptorTest {
                                     new Monomial("-", new OneIdentifier(1))))));
 
                     obj.parse("number = methodName(0, instance, -1)");
+                    Attribute actual = obj.carve();
+
+                    assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);
+                }
+
+                @Test
+                void 引数のないメソッドのインスタンスを返す() {
+                    Attribute expected = new Attribute(new Name("number"));
+                    expected.setDefaultValue(new DefaultValue(new Binomial(".",
+                            new MethodCall("methods"),
+                            new OneIdentifier("instance"))));
+
+                    obj.parse("number = methods().instance");
+                    Attribute actual = obj.carve();
+
+                    assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);
+                }
+
+                @Test
+                void 引数のあるメソッドの引数のあるメソッドを返す() {
+                    Attribute expected = new Attribute(new Name("number"));
+                    expected.setDefaultValue(new DefaultValue(new Binomial(".",
+                            new MethodCall("methods", new OneIdentifier("with"), new OneIdentifier("arg")),
+                            new MethodCall("method", new OneIdentifier(1), new OneIdentifier(2), new OneIdentifier(3)))));
+
+                    obj.parse("number = methods(with, arg).method(1, 2, 3)");
+                    Attribute actual = obj.carve();
+
+                    assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);
+                }
+
+                @Test
+                void 引数のないメソッドの引数のあるメソッドのインスタンスを返す() {
+                    Attribute expected = new Attribute(new Name("number"));
+                    expected.setDefaultValue(new DefaultValue(new Binomial(".",
+                            new Binomial(".",
+                                    new MethodCall("methods"),
+                                    new MethodCall("method", new OneIdentifier(1), new OneIdentifier(2), new OneIdentifier(3))),
+                            new OneIdentifier("inInstance"))));
+
+                    obj.parse("number = methods().method(1, 2, 3).inInstance");
+                    Attribute actual = obj.carve();
+
+                    assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);
+                }
+
+                @Test
+                void 引数のあるメソッドの引数のあるメソッドの引数のあるメソッドの引数のあるメソッドを返す() {
+                    Attribute expected = new Attribute(new Name("number"));
+                    expected.setDefaultValue(new DefaultValue(new Binomial(".",
+                            new Binomial(".",
+                                    new Binomial(".",
+                                            new MethodCall("method", new OneIdentifier("arg1")),
+                                            new MethodCall("forMethod", new OneIdentifier("arg2"))),
+                                    new MethodCall("ofMethod", new OneIdentifier("arg3"))),
+                            new MethodCall("inMethod", new OneIdentifier("arg4")))));
+
+                    obj.parse("number = method(arg1).forMethod(arg2).ofMethod(arg3).inMethod(arg4)");
                     Attribute actual = obj.carve();
 
                     assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);

--- a/src/test/java/sculptor/AttributeSculptorTest.java
+++ b/src/test/java/sculptor/AttributeSculptorTest.java
@@ -1,9 +1,16 @@
 package sculptor;
 
 import feature.Attribute;
+import feature.multiplicity.Bounder;
+import feature.multiplicity.MultiplicityRange;
 import feature.name.Name;
+import feature.type.Type;
+import feature.value.DefaultValue;
+import feature.value.expression.OneIdentifier;
+import feature.visibility.Visibility;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import parser.ClassFeatureParser;
@@ -43,13 +50,128 @@ class AttributeSculptorTest {
             }
 
             @Test
-            void 設定した文字列を返す() {
+            void 設定したインスタンスを返す() {
                 Attribute expected = new Attribute(new Name("name"));
 
                 obj.parse("name");
                 Attribute actual = obj.carve();
 
                 assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);
+            }
+        }
+
+        @Nested
+        class 名前と可視性の場合 {
+
+            @BeforeEach
+            void setup() {
+                obj = new AttributeSculptor();
+            }
+
+            @Test
+            void 設定したインスタンスを返す() {
+                Attribute expected = new Attribute(new Name("name"));
+                expected.setVisibility(Visibility.Private);
+
+                obj.parse("- name");
+                Attribute actual = obj.carve();
+
+                assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);
+            }
+        }
+
+        @Nested
+        class 名前と派生の場合 {
+
+            @BeforeEach
+            void setup() {
+                obj = new AttributeSculptor();
+            }
+
+            @Test
+            void 設定したインスタンスを返す() {
+                Attribute expected = new Attribute(new Name("name"));
+                expected.setDerived(true);
+
+                obj.parse("/name");
+                Attribute actual = obj.carve();
+
+                assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);
+            }
+        }
+
+        @Nested
+        class 名前と型の場合 {
+
+            @BeforeEach
+            void setup() {
+                obj = new AttributeSculptor();
+            }
+
+            @Test
+            void 設定したインスタンスを返す() {
+                Attribute expected = new Attribute(new Name("number"));
+                expected.setType(new Type("int"));
+
+                obj.parse("number : int");
+                Attribute actual = obj.carve();
+
+                assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);
+            }
+        }
+
+        @Nested
+        class 名前と多重度の場合 {
+
+            @BeforeEach
+            void setup() {
+                obj = new AttributeSculptor();
+            }
+
+            @Test
+            void 上限のみを設定したインスタンスを返す() {
+                Attribute expected = new Attribute(new Name("number"));
+                expected.setMultiplicityRange(new MultiplicityRange(new Bounder("*")));
+
+                obj.parse("number[*]");
+                Attribute actual = obj.carve();
+
+                assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);
+            }
+
+            @Test
+            void 上限および下限を設定したインスタンスを返す() {
+                Attribute expected = new Attribute(new Name("number"));
+                expected.setMultiplicityRange(new MultiplicityRange(new Bounder("0"), new Bounder("1")));
+
+                obj.parse("number[0..1]");
+                Attribute actual = obj.carve();
+
+                assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);
+            }
+        }
+
+        @Nested
+        class 名前と既定値の場合 {
+
+            @Nested
+            class 項が1つの場合 {
+
+                @BeforeEach
+                void setup() {
+                    obj = new AttributeSculptor();
+                }
+
+                @Test
+                void デフォルト数値のインスタンスを返す() {
+                    Attribute expected = new Attribute(new Name("number"));
+                    expected.setDefaultValue(new DefaultValue(new OneIdentifier(0)));
+
+                    obj.parse("number = 0");
+                    Attribute actual = obj.carve();
+
+                    assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);
+                }
             }
         }
     }

--- a/src/test/java/sculptor/AttributeSculptorTest.java
+++ b/src/test/java/sculptor/AttributeSculptorTest.java
@@ -1,5 +1,7 @@
 package sculptor;
 
+import feature.Attribute;
+import feature.name.Name;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -15,7 +17,7 @@ class AttributeSculptorTest {
     AttributeSculptor obj;
 
     @Nested
-    class 正しい属性文の場合 {
+    class 正しい属性文の際 {
 
         @BeforeEach
         void setup() {
@@ -31,10 +33,29 @@ class AttributeSculptorTest {
 
             assertThat(actual).isInstanceOf(ClassFeatureParser.PropertyContext.class);
         }
+
+        @Nested
+        class 名前のみの場合 {
+
+            @BeforeEach
+            void setup() {
+                obj = new AttributeSculptor();
+            }
+
+            @Test
+            void 設定した文字列を返す() {
+                Attribute expected = new Attribute(new Name("name"));
+
+                obj.parse("name");
+                Attribute actual = obj.carve();
+
+                assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);
+            }
+        }
     }
 
     @Nested
-    class 不正な属性文の場合 {
+    class 不正な属性文の際 {
 
         @BeforeEach
         void setup() {

--- a/src/test/java/sculptor/AttributeSculptorTest.java
+++ b/src/test/java/sculptor/AttributeSculptorTest.java
@@ -4,6 +4,7 @@ import feature.Attribute;
 import feature.multiplicity.Bounder;
 import feature.multiplicity.MultiplicityRange;
 import feature.name.Name;
+import feature.property.*;
 import feature.type.Type;
 import feature.value.DefaultValue;
 import feature.value.expression.*;
@@ -351,6 +352,53 @@ class AttributeSculptorTest {
 
                     assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);
                 }
+            }
+        }
+
+        @Nested
+        class 名前とプロパティの場合 {
+
+            @BeforeEach
+            void setup() {
+                obj = new AttributeSculptor();
+            }
+
+            @Test
+            void プロパティが1つのインスタンスを返す() {
+                Attribute expected = new Attribute(new Name("number"));
+                expected.addProperty(new ReadOnly());
+
+                obj.parse("number {readOnly}");
+                Attribute actual = obj.carve();
+
+                assertThat(actual).hasToString(expected.toString());
+            }
+
+            @Test
+            void 複雑なプロパティが1つのインスタンスを返す() {
+                Attribute expected = new Attribute(new Name("number"));
+                expected.addProperty(new Redefines(new OneIdentifier("redefinedNumber")));
+
+                obj.parse("number {redefines redefinedNumber}");
+                Attribute actual = obj.carve();
+
+                assertThat(actual).hasToString(expected.toString());
+            }
+
+            @Test
+            void プロパティが6つのインスタンスを返す() {
+                Attribute expected = new Attribute(new Name("number"));
+                expected.addProperty(new ReadOnly());
+                expected.addProperty(new Union());
+                expected.addProperty(new Subsets(new MethodCall("getNumber")));
+                expected.addProperty(new Redefines(new Binomial("+", new OneIdentifier("number"), new OneIdentifier(1))));
+                expected.addProperty(new Ordered());
+                expected.addProperty(new Unique());
+
+                obj.parse("number {readOnly, union, subsets getNumber(), redefines number + 1, ordered, unique}");
+                Attribute actual = obj.carve();
+
+                assertThat(actual).hasToString(expected.toString());
             }
         }
     }

--- a/src/test/java/sculptor/AttributeSculptorTest.java
+++ b/src/test/java/sculptor/AttributeSculptorTest.java
@@ -1,0 +1,59 @@
+package sculptor;
+
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import parser.ClassFeatureParser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+class AttributeSculptorTest {
+
+    AttributeSculptor obj;
+
+    @Nested
+    class 正しい属性文の場合 {
+
+        @BeforeEach
+        void setup() {
+            obj = new AttributeSculptor();
+        }
+
+        @Test
+        void 取得するコンテキストがPropertyContext型である() {
+            String text = "- attribute";
+
+            obj.parse(text);
+            ParserRuleContext actual = obj.getContext();
+
+            assertThat(actual).isInstanceOf(ClassFeatureParser.PropertyContext.class);
+        }
+    }
+
+    @Nested
+    class 不正な属性文の場合 {
+
+        @BeforeEach
+        void setup() {
+            obj = new AttributeSculptor();
+        }
+
+        @Test
+        void 空文字をパースしようとすると例外を投げる() {
+            assertThatThrownBy(() -> obj.parse("")).isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        void nullをパースしようとすると例外を投げる() {
+            assertThatThrownBy(() -> obj.parse(null)).isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        void パースする前にコンテキストを取得しようとすると例外を投げる() {
+            assertThatThrownBy(() -> obj.getContext()).isInstanceOf(IllegalStateException.class);
+        }
+    }
+}


### PR DESCRIPTION
- 属性文のインスタンスを生成
    - 属性文の名前のインスタンスを生成
    - 属性文の可視性のインスタンスを生成
    - 属性文の派生のフィールドを生成
    - 属性文の型のインスタンスを生成
    - 属性文の多重度のインスタンスを生成
    - 属性文の既定値のインスタンスを生成
    - 属性文のプロパティのインスタンスのリストを生成
- jMockitoのバージョンを1.38に固定（詳細はIssue https://github.com/Morichan/fescue/issues/46 参照）