### PR TITLE
Java10への移行（挫折）

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk9
+  - oraclejdk10
 
 sudo: required
 
@@ -11,7 +11,7 @@ bundler_args: --without production --deployment
 
 
 
-# Gradleを最新版へ変更（古い場合はJava9に未対応）
+# Gradleを最新版へ変更（古い場合はJava9以降に未対応）
 before_install:
   - travis_retry curl -s api.sdkman.io | bash
   - travis_retry source /home/travis/.sdkman/bin/sdkman-init.sh # ターミナル上での表示結果を参考

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk10
+  - oraclejdk9
 
 sudo: required
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,8 @@ buildscript {
     }
 }
 
+
+
 apply plugin: 'org.junit.platform.gradle.plugin'
 apply plugin: 'antlr'
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ version '0.3.1'
 
 apply plugin: 'java'
 
-sourceCompatibility = 9
+sourceCompatibility = 10
 tasks.withType(AbstractCompile)*.options*.encoding = tasks.withType(GroovyCompile)*.groovyOptions*.encoding = 'UTF-8'
 
 buildscript {

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ version '0.3.1'
 
 apply plugin: 'java'
 
-sourceCompatibility = 10
+sourceCompatibility = 9
 tasks.withType(AbstractCompile)*.options*.encoding = tasks.withType(GroovyCompile)*.groovyOptions*.encoding = 'UTF-8'
 
 buildscript {

--- a/src/main/java/feature/value/expression/Identifier.java
+++ b/src/main/java/feature/value/expression/Identifier.java
@@ -1,7 +1,5 @@
 package feature.value.expression;
 
-import javafx.css.Match;
-
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/src/test/java/usage/OperationEvaluationTest.java
+++ b/src/test/java/usage/OperationEvaluationTest.java
@@ -2,7 +2,6 @@ package usage;
 
 import org.antlr.v4.runtime.InputMismatchException;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -171,8 +170,6 @@ class OperationEvaluationTest {
                 }
             }
 
-            /*
-            @Disabled("TravisCI上で実行不可")
             @Nested
             class プロパティ名を持つプロパティが1つであれば {
 
@@ -192,7 +189,6 @@ class OperationEvaluationTest {
                     assertThat(actual).isEqualTo(expected);
                 }
             }
-            */
         }
     }
 

--- a/src/test/java/usage/OperationEvaluationTest.java
+++ b/src/test/java/usage/OperationEvaluationTest.java
@@ -2,6 +2,7 @@ package usage;
 
 import org.antlr.v4.runtime.InputMismatchException;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -170,6 +171,7 @@ class OperationEvaluationTest {
                 }
             }
 
+            @Disabled("TravisCI上で実行不可")
             @Nested
             class プロパティ名を持つプロパティが1つであれば {
 

--- a/src/test/java/usage/OperationEvaluationTest.java
+++ b/src/test/java/usage/OperationEvaluationTest.java
@@ -171,6 +171,7 @@ class OperationEvaluationTest {
                 }
             }
 
+            /*
             @Disabled("TravisCI上で実行不可")
             @Nested
             class プロパティ名を持つプロパティが1つであれば {
@@ -191,6 +192,7 @@ class OperationEvaluationTest {
                     assertThat(actual).isEqualTo(expected);
                 }
             }
+            */
         }
     }
 


### PR DESCRIPTION
- javafxパッケージ内へのインポート文の除去
- コメントの修正

ローカル上ではビルドおよびテストが実行成功するが、Travis CI上ではテストがうまくいかなかった。
具体的には、<code>OperationEvaluationTest#正しい文法を入力する際に#プロパティを含む場合#プロパティを持つプロパティが1つであれば.class</code>が存在しないというエラーであった。
また、それを消しても<code>OperationEvaluationTest#正しい文法を入力する際に#プロパティを含む場合.class</code>の別のクラスでエラーが発生した。

詳細は https://travis-ci.org/Morichan/fescue/builds/394385819 を参照