### PR TITLE
feat: OperationSculptorクラスの作成とリリース版の完成

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'grammars'
-version '0.3.1'
+version '1.0.0'
 
 apply plugin: 'java'
 

--- a/src/main/java/evaluation/OperationEvaluation.java
+++ b/src/main/java/evaluation/OperationEvaluation.java
@@ -112,14 +112,17 @@ public class OperationEvaluation extends FeatureEvaluation {
      */
     private void confirmExtractingName() {
         String name = null;
+        boolean isHadParamParen = false;
 
         for (int i = 0; i < context.getChildCount(); i++) {
             if (context.getChild(i) instanceof ClassFeatureParser.NameContext) {
                 name = context.getChild(i).getText();
+            } else if (context.getChild(i) instanceof ClassFeatureParser.ParameterListContext) {
+                isHadParamParen = true;
                 break;
             }
             if (context.exception != null) throw context.exception;
         }
-        if (name == null || name.equals("<missing IDENTIFIER>")) throw new IllegalArgumentException();
+        if (!isHadParamParen || name.contains("<missing")) throw new IllegalArgumentException();
     }
 }

--- a/src/main/java/evaluation/OperationEvaluation.java
+++ b/src/main/java/evaluation/OperationEvaluation.java
@@ -88,41 +88,20 @@ public class OperationEvaluation extends FeatureEvaluation {
         FeatureEvalListener listener = walk(parser.operation());
         context = listener.getOperation();
 
-        confirmExtractingName();
+        //confirmExtractingName();
     }
 
+    /**
+     * <p> 字句解析および構文解析結果のコンテキストを取得します。 </p>
+     *
+     * <p>
+     *     {@link #walk()}を実行する前にこのメソッドを実行すると{@link IllegalStateException}を投げます。
+     * </p>
+     *
+     * @return 字句解析および構文解析結果のコンテキスト
+     */
     public ClassFeatureParser.OperationContext getContext() {
         if (context == null) throw new IllegalStateException();
         return context;
-    }
-
-
-
-    /**
-     * <p> 操作名が抽出できるかどうか確認します。 </p>
-     *
-     * <p>
-     *     次の場合は例外を投げます。
-     * </p>
-     *
-     * <ul>
-     *     <li>操作文を設定していない場合（{@link #setText(String)}参照） : {@link IllegalArgumentException}</li>
-     *     <li>設定した操作文が操作文としての形式と正しくない場合 : {@link ClassFeatureParser.OperationContext#exception}</li>
-     * </ul>
-     */
-    private void confirmExtractingName() {
-        String name = null;
-        boolean isHadParamParen = false;
-
-        for (int i = 0; i < context.getChildCount(); i++) {
-            if (context.getChild(i) instanceof ClassFeatureParser.NameContext) {
-                name = context.getChild(i).getText();
-            } else if (context.getChild(i) instanceof ClassFeatureParser.ParameterListContext) {
-                isHadParamParen = true;
-                break;
-            }
-            if (context.exception != null) throw context.exception;
-        }
-        if (!isHadParamParen || name.contains("<missing")) throw new IllegalArgumentException();
     }
 }

--- a/src/main/java/evaluation/OperationEvaluation.java
+++ b/src/main/java/evaluation/OperationEvaluation.java
@@ -1,0 +1,125 @@
+package evaluation;
+
+import parser.ClassFeatureParser;
+
+/**
+ * <p> 操作における要素の評価クラス </p>
+ *
+ * <p> 簡単な使い方を次に示します。</p>
+ *
+ * <pre>
+ *     {@code
+ *     OperationEvaluation evaluation = new OperationEvaluation();
+ *     evaluation.setText("+ operation() : int");
+ *     evaluation.walk();
+ *
+ *     ClassFeatureParser.OperationContext context = evaluation.getContext();
+ *     // ...
+ *     }
+ * </pre>
+ *
+ * <p>
+ *     最初に操作文をセットし、走査してからコンテキストを取得してください。
+ *     順番を変えると例外として{@link IllegalArgumentException}や{@link org.antlr.v4.runtime.InputMismatchException}を投げます。
+ * </p>
+ */
+public class OperationEvaluation extends FeatureEvaluation {
+
+    /**
+     * 操作文コンテキスト
+     */
+    private ClassFeatureParser.OperationContext context;
+
+    /**
+     * 操作文
+     */
+    private String operation;
+
+    /**
+     * <p> 操作文を設定します。 </p>
+     *
+     * <p>
+     *     {@code "\\.\\."}という文字列（2つ連続したドット）が存在した場合、その両端に半角スペースを挿入します。
+     *     これは、多重度における下限と上限の指定の箇所をパースする際に、ANTLR4の仕様により半角スペースが入っていない場合はうまくパースできないためです。
+     *     詳しくは{@link #insertSpaceBothEndsOfRangeOperator(String)}を参照してください。
+     * </p>
+     *
+     * @param text 設定する操作文 <br>
+     *     {@code null}不可（{@link #insertSpaceBothEndsOfRangeOperator(String)}で{@link IllegalArgumentException}を投げます。）
+     */
+    @Override
+    public void setText(String text) {
+        operation = insertSpaceBothEndsOfRangeOperator(text);
+    }
+
+    /**
+     * <p> 操作文を取得します。 </p>
+     *
+     * <p>
+     *     {@link #setText(String)}を実行する前にこのメソッドを実行した場合は{@link IllegalStateException}を投げます。
+     * </p>
+     *
+     * @return 属性文 <br> {@code null}なし
+     */
+    @Override
+    public String getText() {
+        if (operation == null) throw new IllegalStateException();
+        return operation;
+    }
+
+    /**
+     * <p> 字句解析と構文解析を行い、構文解析木を走査します。 </p>
+     *
+     * <p>
+     *     次の場合は例外を投げます。
+     * </p>
+     *
+     * <ul>
+     *     <li>操作文を設定していない場合（{@link #setText(String)}参照） : {@link IllegalArgumentException}</li>
+     *     <li>設定した操作文が予約語と同じ文字列の場合 : {@link ClassFeatureParser.OperationContext#exception}</li>
+     * </ul>
+     */
+    @Override
+    public void walk() {
+        initIfIsSameBetweenNameAndKeyword();
+        if (operation == null) throw new IllegalArgumentException();
+
+        ClassFeatureParser parser = generateParser(operation);
+        FeatureEvalListener listener = walk(parser.operation());
+        context = listener.getOperation();
+
+        confirmExtractingName();
+    }
+
+    public ClassFeatureParser.OperationContext getContext() {
+        if (context == null) throw new IllegalStateException();
+        return context;
+    }
+
+
+
+    /**
+     * <p> 操作名が抽出できるかどうか確認します。 </p>
+     *
+     * <p>
+     *     次の場合は例外を投げます。
+     * </p>
+     *
+     * <ul>
+     *     <li>操作文を設定していない場合（{@link #setText(String)}参照） : {@link IllegalArgumentException}</li>
+     *     <li>設定した操作文が予約語と同じ文字列の場合 : {@link ClassFeatureParser.OperationContext#exception}</li>
+     * </ul>
+     */
+    private void confirmExtractingName() {
+        String name = null;
+
+        for (int i = 0; i < context.getChildCount(); i++) {
+            if (context.getChild(i) instanceof ClassFeatureParser.NameContext) {
+                name = context.getChild(i).getText();
+                break;
+            }
+            if (context.exception != null) throw context.exception;
+        }
+        if (name == null) throw new IllegalArgumentException();
+    }
+}

--- a/src/main/java/evaluation/OperationEvaluation.java
+++ b/src/main/java/evaluation/OperationEvaluation.java
@@ -120,6 +120,6 @@ public class OperationEvaluation extends FeatureEvaluation {
             }
             if (context.exception != null) throw context.exception;
         }
-        if (name == null) throw new IllegalArgumentException();
+        if (name == null || name.equals("<missing IDENTIFIER>")) throw new IllegalArgumentException();
     }
 }

--- a/src/main/java/evaluation/OperationEvaluation.java
+++ b/src/main/java/evaluation/OperationEvaluation.java
@@ -107,7 +107,7 @@ public class OperationEvaluation extends FeatureEvaluation {
      *
      * <ul>
      *     <li>操作文を設定していない場合（{@link #setText(String)}参照） : {@link IllegalArgumentException}</li>
-     *     <li>設定した操作文が予約語と同じ文字列の場合 : {@link ClassFeatureParser.OperationContext#exception}</li>
+     *     <li>設定した操作文が操作文としての形式と正しくない場合 : {@link ClassFeatureParser.OperationContext#exception}</li>
      * </ul>
      */
     private void confirmExtractingName() {

--- a/src/main/java/sculptor/AttributeSculptor.java
+++ b/src/main/java/sculptor/AttributeSculptor.java
@@ -24,6 +24,32 @@ import java.util.concurrent.Callable;
  * <p>
  *     属性文を入力することで、{@link feature.Attribute}クラスのインスタンス化を行います。
  * </p>
+ *
+ * <pre>
+ *     {@code
+ *     import sculptor.AttributeSculptor;
+ *     import feature.Attribute;
+ *
+ *     class Main {
+ *         // 使い方
+ *         public static void main(String[] args) {
+ *             AttributeSculptor sculptor = new AttributeSculptor();
+ *             Attribute attribute;
+ *
+ *             // 属性文を構文解析します
+ *             sculptor.parse("- number : int");
+ *             // 構文解析結果をAttributeクラスのインスタンスとして出力します
+ *             attribute = sculptor.carve();
+ *
+ *             // 全体像を出力します
+ *             System.out.println(attribute); // "- number : int"
+ *             // 各項目を出力します
+ *             System.out.println(attribute.getName()); // "number"
+ *             System.out.println(attribute.getType()); // "int"
+ *         }
+ *     }
+ *     }
+ * </pre>
  */
 public class AttributeSculptor {
 

--- a/src/main/java/sculptor/AttributeSculptor.java
+++ b/src/main/java/sculptor/AttributeSculptor.java
@@ -134,6 +134,8 @@ public class AttributeSculptor {
         return feature;
     }
 
+
+
     /**
      * <p> 式インスタンスを生成します。 </p>
      *
@@ -234,8 +236,8 @@ public class AttributeSculptor {
      * <p> プロパティインスタンスリストを生成します。 </p>
      *
      * <p>
-     *     プロパティの文字列（{@code toString()}メソッド）で判断し、その文字列に対応するインスタンスをリスト化します。
-     *     式が付随するプロパティについては{@link #extractExpressionsFromArguments(ClassFeatureParser.ArgumentsContext)}を用います。
+     *     プロパティの文字列で判断し、その文字列に対応するインスタンスをリスト化します。
+     *     式が付随するプロパティについては{@link #extractExpressionFromProperty(ClassFeatureParser.PropertyNameContext)}を用います。
      * </p>
      *
      * <p>
@@ -249,7 +251,7 @@ public class AttributeSculptor {
         List<Property> properties = new ArrayList<>();
 
         for (int i = 1; i < ctx.getChildCount(); i += 2) {
-            String propertyString = ctx.getChild(i).getChild(0).toString();
+            String propertyString = ctx.getChild(i).getChild(0).getText();
             if (propertyString.equals("readOnly")) {
                 properties.add(new ReadOnly());
             } else if (propertyString.equals("union")) {
@@ -288,7 +290,7 @@ public class AttributeSculptor {
         if (ctx.getChild(0) instanceof ClassFeatureParser.ExpressionContext) {
             return createExpression((ClassFeatureParser.ExpressionContext) ctx.getChild(0));
         } else {
-            return new OneIdentifier(ctx.getChild(0).getChild(0).toString());
+            return new OneIdentifier(ctx.getChild(0).getChild(0).getText());
         }
     }
 }

--- a/src/main/java/sculptor/OperationSculptor.java
+++ b/src/main/java/sculptor/OperationSculptor.java
@@ -19,6 +19,39 @@ import parser.ClassFeatureParser;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * <p> 操作彫刻家 </p>
+ *
+ * <p>
+ *     操作文を入力することで、{@link feature.Operation}クラスのインスタンス化を行います。
+ * </p>
+ *
+ * <pre>
+ *     {@code
+ *     import sculptor.OperationSculptor;
+ *     import feature.Operation;
+ *
+ *     class Main {
+ *         // 使い方
+ *         public static void main(String[] args) {
+ *             OperationSculptor sculptor = new OperationSculptor();
+ *             Operation operation;
+ *
+ *             // 操作文を構文解析します
+ *             sculptor.parse("+ setNumber(number : int) : void");
+ *             // 構文解析結果をOperationクラスのインスタンスとして出力します
+ *             operation = sculptor.carve();
+ *
+ *             // 全体像を出力します
+ *             System.out.println(operation); // "+ setNumber(number : int) : void"
+ *             // 各項目を出力します
+ *             System.out.println(operation.getName()); // "setNumber"
+ *             System.out.println(operation.getReturnType()); // "void"
+ *         }
+ *     }
+ *     }
+ * </pre>
+ */
 public class OperationSculptor {
 
     private OperationEvaluation evaluation;

--- a/src/main/java/sculptor/OperationSculptor.java
+++ b/src/main/java/sculptor/OperationSculptor.java
@@ -132,6 +132,8 @@ public class OperationSculptor {
         return feature;
     }
 
+
+
     /**
      * <p> 操作文におけるパラメータコンテキストから{@link Parameter}インスタンスリストを形成します。 </p>
      *
@@ -276,25 +278,25 @@ public class OperationSculptor {
     }
 
     /**
-     * <p> プロパティインスタンスリストを生成します。 </p>
+     * <p> パラメータにおけるプロパティインスタンスリストを生成します。 </p>
      *
      * <p>
-     *     プロパティの文字列（{@code toString()}メソッド）で判断し、その文字列に対応するインスタンスをリスト化します。
-     *     式が付随するプロパティについては{@link #extractExpressionsFromArguments(ClassFeatureParser.ArgumentsContext)}を用います。
+     *     パラメータにおけるプロパティの文字列で判断し、その文字列に対応するインスタンスをリスト化します。
+     *     式が付随するプロパティについては{@link #extractExpressionFromProperty(ClassFeatureParser.PropertyNameContext)}を用います。
      * </p>
      *
      * <p>
      *     このメソッドは{@link AttributeSculptor#extractProperties(ClassFeatureParser.PropertiesContext)}と完全に一緒です。
      * </p>
      *
-     * @param ctx プロパティコンテキスト <br> {@code null}については{@link NullPointerException}を投げるはず
+     * @param ctx パラメータにおけるプロパティコンテキスト <br> {@code null}については{@link NullPointerException}を投げるはず
      * @return プロパティインスタンスリスト <br> リストの要素数が{@code 0}の可能性あり
      */
     private List<Property> extractParamProperties(ClassFeatureParser.PropertiesContext ctx) {
         List<Property> properties = new ArrayList<>();
 
         for (int i = 1; i < ctx.getChildCount(); i += 2) {
-            String propertyString = ctx.getChild(i).getChild(0).toString();
+            String propertyString = ctx.getChild(i).getChild(0).getText();
             if (propertyString.equals("readOnly")) {
                 properties.add(new ReadOnly());
             } else if (propertyString.equals("union")) {
@@ -316,28 +318,39 @@ public class OperationSculptor {
     }
 
     /**
-     * <p> プロパティにおける式を抽出します。 </p>
+     * <p> パラメータにおけるプロパティの式を抽出します。 </p>
      *
      * <p>
-     *     プロパティにおける式を{@link #createExpression(ClassFeatureParser.ExpressionContext)}を用いて抽出します。
+     *     パラメータにおけるプロパティの式を{@link #createExpression(ClassFeatureParser.ExpressionContext)}を用いて抽出します。
      * </p>
      *
      * <p>
-     *     このメソッドは{@link AttributeSculptor#extractExpressionFromProperty(ClassFeatureParser.PropertyNameContext)}と、
-     *     また処理は{@link #extractExpressionFromProperty(ClassFeatureParser.OperNameContext)}と完全に一緒です。
+     *     このメソッドは{@link AttributeSculptor#extractExpressionFromProperty(ClassFeatureParser.PropertyNameContext)}と完全に一緒です。
+     *     また処理内容は{@link #extractExpressionFromProperty(ClassFeatureParser.OperNameContext)}と完全に一緒です。
      * </p>
      *
-     * @param ctx プロパティコンテキスト <br> {@code null}については{@link NullPointerException}を投げるはず
+     * @param ctx パラメータにおけるプロパティコンテキスト <br> {@code null}については{@link NullPointerException}を投げるはず
      * @return 式インスタンス <br> {@code null}の可能性なし
      */
     private Expression extractExpressionFromProperty(ClassFeatureParser.PropertyNameContext ctx) {
         if (ctx.getChild(0) instanceof ClassFeatureParser.ExpressionContext) {
             return createExpression((ClassFeatureParser.ExpressionContext) ctx.getChild(0));
         } else {
-            return new OneIdentifier(ctx.getChild(0).getChild(0).toString());
+            return new OneIdentifier(ctx.getChild(0).getChild(0).getText());
         }
     }
 
+    /**
+     * <p> 操作におけるプロパティインスタンスリストを生成します。 </p>
+     *
+     * <p>
+     *     操作におけるプロパティの文字列で判断し、その文字列に対応するインスタンスをリスト化します。
+     *     式が付随するプロパティについては{@link #extractExpressionFromProperty(ClassFeatureParser.OperNameContext)}を用います。
+     * </p>
+     *
+     * @param ctx 操作におけるプロパティコンテキスト <br> {@code null}については{@link NullPointerException}を投げるはず
+     * @return プロパティインスタンスリスト <br> リストの要素数が{@code 0}の可能性あり
+     */
     private List<Property> extractOperationProperties(ClassFeatureParser.OperPropertiesContext ctx) {
         List<Property> properties = new ArrayList<>();
 
@@ -359,25 +372,25 @@ public class OperationSculptor {
     }
 
     /**
-     * <p> プロパティにおける式を抽出します。 </p>
+     * <p> 操作におけるプロパティの式を抽出します。 </p>
      *
      * <p>
-     *     プロパティにおける式を{@link #createExpression(ClassFeatureParser.ExpressionContext)}を用いて抽出します。
+     *     操作におけるプロパティの式を{@link #createExpression(ClassFeatureParser.ExpressionContext)}を用いて抽出します。
      * </p>
      *
      * <p>
-     *     このメソッドは{@link AttributeSculptor#extractExpressionFromProperty(ClassFeatureParser.PropertyNameContext)}と完全に一緒です。
-     *     また処理は{@link #extractExpressionFromProperty(ClassFeatureParser.PropertyNameContext)}と完全に一緒です。
+     *     このメソッドにおける処理内容は{@link AttributeSculptor#extractExpressionFromProperty(ClassFeatureParser.PropertyNameContext)}
+     *     および{@link #extractExpressionFromProperty(ClassFeatureParser.PropertyNameContext)}と完全に一緒です。
      * </p>
      *
-     * @param ctx プロパティコンテキスト <br> {@code null}については{@link NullPointerException}を投げるはず
+     * @param ctx 操作におけるプロパティコンテキスト <br> {@code null}については{@link NullPointerException}を投げるはず
      * @return 式インスタンス <br> {@code null}の可能性なし
      */
     private Expression extractExpressionFromProperty(ClassFeatureParser.OperNameContext ctx) {
         if (ctx.getChild(0) instanceof ClassFeatureParser.ExpressionContext) {
             return createExpression((ClassFeatureParser.ExpressionContext) ctx.getChild(0));
         } else {
-            return new OneIdentifier(ctx.getChild(0).getChild(0).toString());
+            return new OneIdentifier(ctx.getChild(0).getChild(0).getText());
         }
     }
 }

--- a/src/main/java/sculptor/OperationSculptor.java
+++ b/src/main/java/sculptor/OperationSculptor.java
@@ -124,7 +124,7 @@ public class OperationSculptor {
                 if (ctx.getChildCount() > 2)
                     feature.setParameters(extractParameters((ClassFeatureParser.ParameterListContext) ctx));
 
-            } else if (ctx instanceof ClassFeatureParser.OperPropertiesContext) {
+            } else { // if (ctx instanceof ClassFeatureParser.OperPropertiesContext) {
                 feature.setProperties(extractOperationProperties((ClassFeatureParser.OperPropertiesContext) ctx));
             }
         }
@@ -169,7 +169,7 @@ public class OperationSculptor {
                     param.setDefaultValue(new DefaultValue(
                             createExpression((ClassFeatureParser.ExpressionContext) paramItem.getChild(1))));
 
-                } else if (paramItem instanceof ClassFeatureParser.ParamPropertiesContext) {
+                } else { // if (paramItem instanceof ClassFeatureParser.ParamPropertiesContext) {
                     param.setProperties(extractParamProperties((ClassFeatureParser.PropertiesContext) paramItem.getChild(0)));
                 }
             }

--- a/src/main/java/usage/AttributeEvaluation.java
+++ b/src/main/java/usage/AttributeEvaluation.java
@@ -11,6 +11,12 @@ import java.util.List;
 /**
  * <p> 属性における要素の抽出クラス </p>
  *
+ * <p>
+ *     @deprecated このクラスはあくまで文字列を構文解析し、その結果を文字列で出力するだけです。
+ *     そのため、ポイントでほしい情報を抽出できず、不完全です。
+ *     {@link sculptor.AttributeSculptor}クラスをご利用ください。
+ * </p>
+ *
  * <p> 簡単な使い方を次に示します。</p>
  *
  * <pre>
@@ -30,6 +36,7 @@ import java.util.List;
  *     順番を変えると例外として{@link IllegalArgumentException}や{@link org.antlr.v4.runtime.InputMismatchException}を投げます。
  * </p>
  */
+@Deprecated
 public class AttributeEvaluation extends FeatureEvaluation {
 
     /**

--- a/src/main/java/usage/OperationEvaluation.java
+++ b/src/main/java/usage/OperationEvaluation.java
@@ -11,6 +11,12 @@ import java.util.List;
 /**
  * <p> 操作における要素の抽出クラス </p>
  *
+ * <p>
+ *     @deprecated このクラスはあくまで文字列を構文解析し、その結果を文字列で出力するだけです。
+ *     そのため、ポイントでほしい情報を抽出できず、不完全です。
+ *     {@link sculptor.OperationSculptor}クラスをご利用ください。
+ * </p>
+ *
  * <p> 簡単な使い方を次に示します。</p>
  *
  * <pre>
@@ -31,6 +37,7 @@ import java.util.List;
  *     順番を変えると例外として{@link IllegalArgumentException}や{@link org.antlr.v4.runtime.InputMismatchException}を投げます。
  * </p>
  */
+@Deprecated
 public class OperationEvaluation extends FeatureEvaluation {
 
     /**

--- a/src/test/java/evaluation/OperationEvaluationTest.java
+++ b/src/test/java/evaluation/OperationEvaluationTest.java
@@ -93,7 +93,7 @@ class OperationEvaluationTest {
         @Test
         void 操作名を設定せずに走査したらエラーを返す() {
 
-            obj.setText("+ () : int");
+            obj.setText("+ (): int");
 
             assertThatThrownBy(() -> obj.walk()).isInstanceOf(IllegalArgumentException.class);
         }

--- a/src/test/java/evaluation/OperationEvaluationTest.java
+++ b/src/test/java/evaluation/OperationEvaluationTest.java
@@ -89,5 +89,13 @@ class OperationEvaluationTest {
 
             assertThatThrownBy(() -> obj.getContext()).isInstanceOf(IllegalStateException.class);
         }
+
+        @Test
+        void 操作名を設定せずに走査したらエラーを返す() {
+
+            obj.setText("+ () : int");
+
+            assertThatThrownBy(() -> obj.walk()).isInstanceOf(IllegalArgumentException.class);
+        }
     }
 }

--- a/src/test/java/evaluation/OperationEvaluationTest.java
+++ b/src/test/java/evaluation/OperationEvaluationTest.java
@@ -2,6 +2,7 @@ package evaluation;
 
 import org.antlr.v4.runtime.InputMismatchException;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import parser.ClassFeatureParser;
@@ -10,20 +11,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 
-class AttributeEvaluationTest {
-    AttributeEvaluation obj;
+class OperationEvaluationTest {
+
+    OperationEvaluation obj;
 
     @Nested
     class 正しい文を入力している場合 {
 
         @BeforeEach
         void setup() {
-            obj = new AttributeEvaluation();
+            obj = new OperationEvaluation();
         }
 
         @Test
         void 文を設定すると文を返す() {
-            String expected = "attribute";
+            String expected = "operation()";
 
             obj.setText(expected);
             String actual = obj.getText();
@@ -33,10 +35,10 @@ class AttributeEvaluationTest {
 
         @Test
         void 文を設定して走査するとエラーを返さない() {
-            String expected = "attribute";
+            String expected = "operation()";
             String actual;
 
-            obj.setText("attribute");
+            obj.setText("operation()");
             obj.walk();
             actual = obj.getText();
 
@@ -45,47 +47,47 @@ class AttributeEvaluationTest {
 
         @Test
         void 文を設定して走査するとコンテキストを返す() {
-            ClassFeatureParser.PropertyContext actual;
+            ClassFeatureParser.OperationContext actual;
 
-            obj.setText("- /attribute");
+            obj.setText("+ operation()");
             obj.walk();
             actual = obj.getContext();
 
-            assertThat(actual).isInstanceOf(ClassFeatureParser.PropertyContext.class);
+            assertThat(actual).isInstanceOf(ClassFeatureParser.OperationContext.class);
         }
     }
 
     @Nested
     class 正しい文を入力していない場合 {
 
+        @BeforeEach
+        void setup() {
+            obj = new OperationEvaluation();
+        }
+
         @Test
         void 文を設定せずに走査したらエラーを返す() {
-            obj = new AttributeEvaluation();
-
             assertThatThrownBy(() -> obj.walk()).isInstanceOf(IllegalArgumentException.class);
         }
 
         @Test
         void 文を設定せずに文を取得しようとしたら例外を投げる() {
-            obj = new AttributeEvaluation();
-
             assertThatThrownBy(() -> obj.getText()).isInstanceOf(IllegalStateException.class);
         }
 
+        @Disabled("AttributeEvaluationTestとの違いが不明だが正しい例外を投げてこない")
         @Test
         void 正しくない文を設定して走査したらエラーを返す() {
-            obj = new AttributeEvaluation();
 
-            obj.setText("- int");
+            obj.setText("+ :int");
 
             assertThatThrownBy(() -> obj.walk()).isInstanceOf(InputMismatchException.class);
         }
 
         @Test
         void 文を走査せずにコンテキストを取得しようとすると例外を投げる() {
-            obj = new AttributeEvaluation();
 
-            obj.setText("attribute");
+            obj.setText("operation()");
 
             assertThatThrownBy(() -> obj.getContext()).isInstanceOf(IllegalStateException.class);
         }

--- a/src/test/java/evaluation/OperationEvaluationTest.java
+++ b/src/test/java/evaluation/OperationEvaluationTest.java
@@ -75,27 +75,11 @@ class OperationEvaluationTest {
         }
 
         @Test
-        void 正しくない文を設定して走査したらエラーを返す() {
-
-            obj.setText("int int()");
-
-            assertThatThrownBy(() -> obj.walk()).isInstanceOf(InputMismatchException.class);
-        }
-
-        @Test
         void 文を走査せずにコンテキストを取得しようとしたら例外を投げる() {
 
             obj.setText("operation()");
 
             assertThatThrownBy(() -> obj.getContext()).isInstanceOf(IllegalStateException.class);
-        }
-
-        @Test
-        void 操作名を設定せずに走査したらエラーを返す() {
-
-            obj.setText("+ (): int");
-
-            assertThatThrownBy(() -> obj.walk()).isInstanceOf(IllegalArgumentException.class);
         }
     }
 }

--- a/src/test/java/evaluation/OperationEvaluationTest.java
+++ b/src/test/java/evaluation/OperationEvaluationTest.java
@@ -2,7 +2,6 @@ package evaluation;
 
 import org.antlr.v4.runtime.InputMismatchException;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import parser.ClassFeatureParser;
@@ -75,17 +74,16 @@ class OperationEvaluationTest {
             assertThatThrownBy(() -> obj.getText()).isInstanceOf(IllegalStateException.class);
         }
 
-        @Disabled("AttributeEvaluationTestとの違いが不明だが正しい例外を投げてこない")
         @Test
         void 正しくない文を設定して走査したらエラーを返す() {
 
-            obj.setText("+ :int");
+            obj.setText("int int()");
 
             assertThatThrownBy(() -> obj.walk()).isInstanceOf(InputMismatchException.class);
         }
 
         @Test
-        void 文を走査せずにコンテキストを取得しようとすると例外を投げる() {
+        void 文を走査せずにコンテキストを取得しようとしたら例外を投げる() {
 
             obj.setText("operation()");
 

--- a/src/test/java/sculptor/AttributeSculptorTest.java
+++ b/src/test/java/sculptor/AttributeSculptorTest.java
@@ -414,7 +414,7 @@ class AttributeSculptorTest {
             }
 
             @Nested
-            class カッコで囲まれている式の場合 {
+            class カッコで囲っている式の場合 {
 
                 @BeforeEach
                 void setup() {

--- a/src/test/java/sculptor/OperationSculptorTest.java
+++ b/src/test/java/sculptor/OperationSculptorTest.java
@@ -1,0 +1,701 @@
+package sculptor;
+
+import feature.Operation;
+import feature.direction.In;
+import feature.direction.InOut;
+import feature.direction.Out;
+import feature.direction.Return;
+import feature.multiplicity.Bounder;
+import feature.multiplicity.MultiplicityRange;
+import feature.name.Name;
+import feature.parameter.Parameter;
+import feature.property.*;
+import feature.type.Type;
+import feature.value.DefaultValue;
+import feature.value.expression.*;
+import feature.visibility.Visibility;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import parser.ClassFeatureParser;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+class OperationSculptorTest {
+
+    OperationSculptor obj;
+
+    @Nested
+    class 正しい属性文の際 {
+
+        @BeforeEach
+        void setup() {
+            obj = new OperationSculptor();
+        }
+
+        @Test
+        void 取得するコンテキストがOperationContext型である() {
+            String text = "+ operation()";
+
+            obj.parse(text);
+            ParserRuleContext actual = obj.getContext();
+
+            assertThat(actual).isInstanceOf(ClassFeatureParser.OperationContext.class);
+        }
+
+        @Nested
+        class 名前のみの場合 {
+
+            @BeforeEach
+            void setup() {
+                obj = new OperationSculptor();
+            }
+
+            @Test
+            void 設定したインスタンスを返す() {
+                Operation expected = new Operation(new Name("name"));
+
+                obj.parse("name()");
+                Operation actual = obj.carve();
+
+                assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);
+            }
+        }
+
+        @Nested
+        class 名前と可視性の場合 {
+
+            @BeforeEach
+            void setup() {
+                obj = new OperationSculptor();
+            }
+
+            @Test
+            void 設定したインスタンスを返す() {
+                Operation expected = new Operation(new Name("name"));
+                expected.setVisibility(Visibility.Public);
+
+                obj.parse("+ name");
+                Operation actual = obj.carve();
+
+                assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);
+            }
+        }
+
+        @Nested
+        class 名前と型の場合 {
+
+            @BeforeEach
+            void setup() {
+                obj = new OperationSculptor();
+            }
+
+            @Test
+            void 設定したインスタンスを返す() {
+                Operation expected = new Operation(new Name("getNumber"));
+                expected.setReturnType(new Type("int"));
+
+                obj.parse("getNumber() : int");
+                Operation actual = obj.carve();
+
+                assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);
+            }
+
+            @Test
+            void 設定したvoidを返す() {
+                Operation expected = new Operation(new Name("toDo"));
+                expected.setReturnType(new Type("void"));
+
+                obj.parse("toDo() : void");
+                Operation actual = obj.carve();
+
+                assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);
+            }
+        }
+
+        @Nested
+        class パラメータリストにおいて {
+
+            @Nested
+            class 名前と型の場合 {
+
+                @BeforeEach
+                void setup() {
+                    obj = new OperationSculptor();
+                }
+
+                @Test
+                void 名前と型を1つ持つインスタンスを返す() {
+                    Operation expected = new Operation(new Name("setNumber"));
+                    List<Parameter> params = new ArrayList<>();
+                    params.add(new Parameter(new Name("number")));
+                    params.get(0).setType(new Type("int"));
+                    expected.setParameters(params);
+
+                    obj.parse("setNumber(number : int)");
+                    Operation actual = obj.carve();
+
+                    assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);
+                }
+
+                @Test
+                void 名前と型を2つ持つインスタンスを返す() {
+                    Operation expected = new Operation(new Name("setNumber"));
+                    List<Parameter> params = new ArrayList<>();
+                    params.add(new Parameter(new Name("number")));
+                    params.get(0).setType(new Type("int"));
+                    params.add(new Parameter(new Name("number2")));
+                    params.get(1).setType(new Type("int"));
+                    expected.setParameters(params);
+
+                    obj.parse("setNumber(number : int, number2 : int)");
+                    Operation actual = obj.carve();
+
+                    assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);
+                }
+
+                @Test
+                void 名前と型を3つ持つインスタンスを返す() {
+                    Operation expected = new Operation(new Name("calculate"));
+                    List<Parameter> params = new ArrayList<>();
+                    params.add(new Parameter(new Name("number")));
+                    params.get(0).setType(new Type("int"));
+                    params.add(new Parameter(new Name("text")));
+                    params.get(1).setType(new Type("char"));
+                    params.add(new Parameter(new Name("price")));
+                    params.get(2).setType(new Type("double"));
+                    expected.setParameters(params);
+
+                    obj.parse("calculate(number : int, text : char, price : double)");
+                    Operation actual = obj.carve();
+
+                    assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);
+                }
+            }
+
+            @Nested
+            class 名前と型と方向の場合 {
+
+                @BeforeEach
+                void setup() {
+                    obj = new OperationSculptor();
+                }
+
+                @Test
+                void 方向がinの名前と型を1つ持つインスタンスを返す() {
+                    Operation expected = new Operation(new Name("setNumber"));
+                    List<Parameter> params = new ArrayList<>();
+                    params.add(new Parameter(new Name("number")));
+                    params.get(0).setType(new Type("int"));
+                    params.get(0).setDirection(new In(true));
+                    expected.setParameters(params);
+
+                    obj.parse("setNumber(in number : int)");
+                    Operation actual = obj.carve();
+
+                    assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);
+                }
+
+                @Test
+                void 方向がoutの名前と型を1つ持つインスタンスを返す() {
+                    Operation expected = new Operation(new Name("getNumber"));
+                    List<Parameter> params = new ArrayList<>();
+                    params.add(new Parameter(new Name("number")));
+                    params.get(0).setType(new Type("int"));
+                    params.get(0).setDirection(new Out());
+                    expected.setParameters(params);
+
+                    obj.parse("getNumber(out number : int)");
+                    Operation actual = obj.carve();
+
+                    assertThat(actual).hasToString(expected.toString());
+                }
+
+                @Test
+                void 方向がinoutの名前と型を1つ持つインスタンスを返す() {
+                    Operation expected = new Operation(new Name("getNumber"));
+                    List<Parameter> params = new ArrayList<>();
+                    params.add(new Parameter(new Name("number")));
+                    params.get(0).setType(new Type("int"));
+                    params.get(0).setDirection(new InOut());
+                    expected.setParameters(params);
+
+                    obj.parse("getNumber(inout number : int)");
+                    Operation actual = obj.carve();
+
+                    assertThat(actual).hasToString(expected.toString());
+                }
+
+                @Test
+                void 方向がreturnの名前と型を1つ持つインスタンスを返す() {
+                    Operation expected = new Operation(new Name("getNumber"));
+                    List<Parameter> params = new ArrayList<>();
+                    params.add(new Parameter(new Name("number")));
+                    params.get(0).setType(new Type("int"));
+                    params.get(0).setDirection(new Return());
+                    expected.setParameters(params);
+
+                    obj.parse("getNumber(return number : int)");
+                    Operation actual = obj.carve();
+
+                    assertThat(actual).hasToString(expected.toString());
+                }
+
+                @Test
+                void 方向と名前と型を4つ持つインスタンスを返す() {
+                    Operation expected = new Operation(new Name("getNumber"));
+                    List<Parameter> params = new ArrayList<>();
+                    params.add(new Parameter(new Name("arg1")));
+                    params.get(0).setType(new Type("char"));
+                    params.get(0).setDirection(new In(true));
+                    params.add(new Parameter(new Name("arg2")));
+                    params.get(1).setType(new Type("double"));
+                    params.get(1).setDirection(new Out());
+                    params.add(new Parameter(new Name("arg3")));
+                    params.get(2).setType(new Type("float"));
+                    params.get(2).setDirection(new InOut());
+                    params.add(new Parameter(new Name("arg4")));
+                    params.get(3).setType(new Type("byte"));
+                    params.get(3).setDirection(new Return());
+                    expected.setParameters(params);
+
+                    obj.parse("getNumber(in arg1 : char, out arg2 : double, inout arg3 : float, return arg4 : byte)");
+                    Operation actual = obj.carve();
+
+                    assertThat(actual).hasToString(expected.toString());
+                }
+            }
+
+            @Nested
+            class 名前と型と多重度の場合 {
+
+                @BeforeEach
+                void setup() {
+                    obj = new OperationSculptor();
+                }
+
+                @Test
+                void 名前と型と多重度を1つ持つインスタンスを返す() {
+                    Operation expected = new Operation(new Name("setNumber"));
+                    List<Parameter> params = new ArrayList<>();
+                    params.add(new Parameter(new Name("text")));
+                    params.get(0).setType(new Type("char"));
+                    params.get(0).setMultiplicityRange(new MultiplicityRange(new Bounder("*")));
+                    expected.setParameters(params);
+
+                    obj.parse("setNumber(text : char [*])");
+                    Operation actual = obj.carve();
+
+                    assertThat(actual).hasToString(expected.toString());
+                }
+
+                @Test
+                void 名前と型と多重度を3つ持つインスタンスを返す() {
+                    Operation expected = new Operation(new Name("setNumber"));
+                    List<Parameter> params = new ArrayList<>();
+                    params.add(new Parameter(new Name("arg1")));
+                    params.get(0).setType(new Type("char"));
+                    params.get(0).setMultiplicityRange(new MultiplicityRange(new Bounder("*")));
+                    params.add(new Parameter(new Name("arg2")));
+                    params.get(1).setType(new Type("char"));
+                    params.get(1).setMultiplicityRange(new MultiplicityRange(
+                            new Bounder(new OneIdentifier(1)), new Bounder("*")));
+                    params.add(new Parameter(new Name("arg3")));
+                    params.get(2).setType(new Type("char"));
+                    params.get(2).setMultiplicityRange(new MultiplicityRange(
+                            new Bounder(new OneIdentifier(0)), new Bounder(new OneIdentifier(1))));
+                    expected.setParameters(params);
+
+                    obj.parse("setNumber(arg1 : char [*], arg2 : char [1..*], arg3 : char [0..1])");
+                    Operation actual = obj.carve();
+
+                    assertThat(actual).hasToString(expected.toString());
+                }
+            }
+
+            @Nested
+            class 名前と型と既定値では {
+
+                @Nested
+                class 項が1つの場合 {
+
+                    @BeforeEach
+                    void setup() {
+                        obj = new OperationSculptor();
+                    }
+
+                    @Test
+                    void 名前と型と既定値を1つ持つインスタンスを返す() {
+                        Operation expected = new Operation(new Name("setNumber"));
+                        List<Parameter> params = new ArrayList<>();
+                        params.add(new Parameter(new Name("number")));
+                        params.get(0).setType(new Type("int"));
+                        params.get(0).setDefaultValue(new DefaultValue(new OneIdentifier(0)));
+                        expected.setParameters(params);
+
+                        obj.parse("setNumber(number : int = 0)");
+                        Operation actual = obj.carve();
+
+                        assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);
+                    }
+
+                    @Test
+                    void 名前と型と既定値を3つ持つインスタンスを返す() {
+                        Operation expected = new Operation(new Name("setNumber"));
+                        List<Parameter> params = new ArrayList<>();
+                        params.add(new Parameter(new Name("arg1")));
+                        params.get(0).setType(new Type("int"));
+                        params.get(0).setDefaultValue(new DefaultValue(new Monomial("-", new OneIdentifier(1))));
+                        params.add(new Parameter(new Name("arg2")));
+                        params.get(1).setType(new Type("double"));
+                        params.get(1).setDefaultValue(new DefaultValue(new OneIdentifier("5.0")));
+                        params.add(new Parameter(new Name("arg3")));
+                        params.get(2).setType(new Type("bool"));
+                        params.get(2).setDefaultValue(new DefaultValue(new Monomial("not", new OneIdentifier("true"))));
+                        expected.setParameters(params);
+
+                        obj.parse("setNumber(arg1 : int = -1, arg2 : double = 5.0, arg3 : bool = not true)");
+                        Operation actual = obj.carve();
+
+                        assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);
+                    }
+                }
+
+                @Nested
+                class 項が2つの場合 {
+
+                    @BeforeEach
+                    void setup() {
+                        obj = new OperationSculptor();
+                    }
+
+                    @Test
+                    void 名前と型と既定値を1つ持つインスタンスを返す() {
+                        Operation expected = new Operation(new Name("setNumber"));
+                        List<Parameter> params = new ArrayList<>();
+                        params.add(new Parameter(new Name("number")));
+                        params.get(0).setType(new Type("int"));
+                        params.get(0).setDefaultValue(new DefaultValue(new Binomial("+",
+                                new OneIdentifier("number"), new OneIdentifier(1))));
+                        expected.setParameters(params);
+
+                        obj.parse("setNumber(number : int = number + 1)");
+                        Operation actual = obj.carve();
+
+                        assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);
+                    }
+
+                    @Test
+                    void 名前と型と既定値を3つ持つインスタンスを返す() {
+                        Operation expected = new Operation(new Name("setNumber"));
+                        List<Parameter> params = new ArrayList<>();
+                        params.add(new Parameter(new Name("arg1")));
+                        params.get(0).setType(new Type("int32"));
+                        params.get(0).setDefaultValue(new DefaultValue(new Binomial(">=",
+                                new OneIdentifier("number"), new OneIdentifier("10"))));
+                        params.add(new Parameter(new Name("arg2")));
+                        params.get(1).setType(new Type("double"));
+                        params.get(1).setDefaultValue(new DefaultValue(new Binomial(".",
+                                new OneIdentifier("instances"), new MethodCall("method", new OneIdentifier("arg")))));
+                        params.add(new Parameter(new Name("arg3")));
+                        params.get(2).setType(new Type("bool"));
+                        params.get(2).setDefaultValue(new DefaultValue(
+                                new Binomial(".", new OneIdentifier("instances"), new OneIdentifier("instance"))));
+                        expected.setParameters(params);
+
+                        obj.parse("setNumber(arg1 : int32 = number >= 10, arg2 : double = instances.method(arg), arg3 : bool = instances.instance)");
+                        Operation actual = obj.carve();
+
+                        assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);
+                    }
+                }
+
+                @Nested
+                class メソッドの場合 {
+
+                    @BeforeEach
+                    void setup() {
+                        obj = new OperationSculptor();
+                    }
+
+                    @Test
+                    void 名前と型と既定値を1つ持つインスタンスを返す() {
+                        Operation expected = new Operation(new Name("setNumber"));
+                        List<Parameter> params = new ArrayList<>();
+                        params.add(new Parameter(new Name("number")));
+                        params.get(0).setType(new Type("int"));
+                        params.get(0).setDefaultValue(new DefaultValue(new MethodCall("methodName")));
+                        expected.setParameters(params);
+
+                        obj.parse("setNumber(number : int = methodName())");
+                        Operation actual = obj.carve();
+
+                        assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);
+                    }
+
+                    @Test
+                    void 名前と型と既定値を3つ持つインスタンスを返す() {
+                        Operation expected = new Operation(new Name("setNumber"));
+                        List<Parameter> params = new ArrayList<>();
+                        params.add(new Parameter(new Name("arg1")));
+                        params.get(0).setType(new Type("int32"));
+                        params.get(0).setDefaultValue(new DefaultValue(
+                                new MethodCall("methodName",
+                                        new OneIdentifier(0),
+                                        new OneIdentifier("instance"),
+                                        new Monomial("-", new OneIdentifier(1)))));
+                        params.add(new Parameter(new Name("arg2")));
+                        params.get(1).setType(new Type("double"));
+                        params.get(1).setDefaultValue(new DefaultValue(new Binomial(".",
+                                new MethodCall("methods", new OneIdentifier("with"), new OneIdentifier("arg")),
+                                new MethodCall("method",
+                                        new OneIdentifier("1.0"),
+                                        new Monomial("-", new OneIdentifier("2.0")),
+                                        new Monomial("+", new OneIdentifier("3.0")),
+                                        new MethodCall("forMethod",
+                                                new MethodCall("ofMethod",
+                                                        new MethodCall("inMethod", new OneIdentifier(0))))))));
+                        params.add(new Parameter(new Name("arg3")));
+                        params.get(2).setType(new Type("bool"));
+                        params.get(2).setDefaultValue(new DefaultValue(new Binomial(".",
+                                new Binomial(".",
+                                        new Binomial(".",
+                                                new MethodCall("method", new OneIdentifier("arg1")),
+                                                new MethodCall("forMethod", new OneIdentifier("arg2"))),
+                                        new MethodCall("ofMethod", new OneIdentifier("arg3"))),
+                                new MethodCall("inMethod", new OneIdentifier("arg4")))));
+                        expected.setParameters(params);
+
+                        obj.parse("setNumber(arg1 : int32 = methodName(0, instance, -1), arg2 : double = methods(with, arg).method(1.0, -2.0, +3.0, forMethod(ofMethod(inMethod(0)))), arg3 : bool = method(arg1).forMethod(arg2).ofMethod(arg3).inMethod(arg4))");
+                        Operation actual = obj.carve();
+
+                        assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);
+                    }
+                }
+
+                @Nested
+                class カッコで囲っている式の場合 {
+
+                    @BeforeEach
+                    void setup() {
+                        obj = new OperationSculptor();
+                    }
+
+                    @Test
+                    void 名前と型と既定値を1つ持つインスタンスを返す() {
+                        Operation expected = new Operation(new Name("setNumber"));
+                        List<Parameter> params = new ArrayList<>();
+                        params.add(new Parameter(new Name("number")));
+                        params.get(0).setType(new Type("int"));
+                        params.get(0).setDefaultValue(new DefaultValue(new ExpressionWithParen(new OneIdentifier("withParen"))));
+                        expected.setParameters(params);
+
+                        obj.parse("setNumber(number : int = (withParen))");
+                        Operation actual = obj.carve();
+
+                        assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);
+                    }
+
+                    @Test
+                    void 名前と型と既定値を3つ持つインスタンスを返す() {
+                        Operation expected = new Operation(new Name("setNumber"));
+                        List<Parameter> params = new ArrayList<>();
+                        params.add(new Parameter(new Name("arg1")));
+                        params.get(0).setType(new Type("f32"));
+                        params.get(0).setDefaultValue(new DefaultValue(
+                                new ExpressionWithParen(new Binomial("/",
+                                        new MethodCall("methodName",
+                                                new OneIdentifier(0),
+                                                new OneIdentifier("instance"),
+                                                new Monomial("-", new OneIdentifier(1))),
+                                        new OneIdentifier(2)))));
+                        params.add(new Parameter(new Name("arg2")));
+                        params.get(1).setType(new Type("i64"));
+                        params.get(1).setDefaultValue(new DefaultValue(new Binomial("*",
+                                new ExpressionWithParen(
+                                        new Binomial("+",
+                                                new OneIdentifier("instance"),
+                                                new Binomial(".",
+                                                        new MethodCall("methods", new OneIdentifier("with"), new OneIdentifier("arg")),
+                                                        new MethodCall("method",
+                                                                new OneIdentifier("1.0"),
+                                                                new Monomial("-", new OneIdentifier("2.0")),
+                                                                new Monomial("+", new OneIdentifier("3.0")),
+                                                                new MethodCall("forMethod",
+                                                                        new MethodCall("ofMethod",
+                                                                                new MethodCall("inMethod", new OneIdentifier(0)))))))),
+                                new OneIdentifier("300000"))));
+                        params.add(new Parameter(new Name("arg3")));
+                        params.get(2).setType(new Type("bool"));
+                        params.get(2).setDefaultValue(new DefaultValue(new Binomial(".",
+                                new Binomial(".",
+                                        new Binomial(".",
+                                                new MethodCall("method", new OneIdentifier("arg1")),
+                                                new MethodCall("forMethod",
+                                                        new Binomial("/",
+                                                                new Binomial("*",
+                                                                        new ExpressionWithParen(
+                                                                                new Binomial("+",
+                                                                                        new OneIdentifier("upperBase"),
+                                                                                        new OneIdentifier("lowerBase"))),
+                                                                        new OneIdentifier("height")),
+                                                                new OneIdentifier(2)))),
+                                        new MethodCall("ofMethod", new OneIdentifier("arg3"))),
+                                new MethodCall("inMethod", new OneIdentifier("arg4")))));
+                        expected.setParameters(params);
+
+                        obj.parse("setNumber(arg1 : f32 = (methodName(0, instance, -1) / 2), arg2 : i64 = (instance + methods(with, arg).method(1.0, -2.0, +3.0, forMethod(ofMethod(inMethod(0))))) * 300000, arg3 : bool = method(arg1).forMethod((upperBase + lowerBase) * height / 2).ofMethod(arg3).inMethod(arg4))");
+                        Operation actual = obj.carve();
+
+                        assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);
+                    }
+                }
+            }
+
+            @Nested
+            class 名前と型とプロパティの場合 {
+
+                @BeforeEach
+                void setup() {
+                    obj = new OperationSculptor();
+                }
+
+                @Test
+                void 名前と型とプロパティを1つ持つインスタンスを返す() {
+                    Operation expected = new Operation(new Name("setNumber"));
+                    List<Parameter> params = new ArrayList<>();
+                    params.add(new Parameter(new Name("number")));
+                    params.get(0).setType(new Type("int"));
+                    params.get(0).addProperty(new ReadOnly());
+                    expected.setParameters(params);
+
+                    obj.parse("setNumber(number : int {readOnly})");
+                    Operation actual = obj.carve();
+
+                    assertThat(actual).hasToString(expected.toString());
+                }
+
+                @Test
+                void 名前と型とプロパティを3つ持つインスタンスを返す() {
+                    Operation expected = new Operation(new Name("setNumber"));
+                    List<Parameter> params = new ArrayList<>();
+                    params.add(new Parameter(new Name("arg1")));
+                    params.get(0).setType(new Type("int32"));
+                    params.get(0).addProperty(new Redefines(new Binomial(".", new OneIdentifier("Class"), new OneIdentifier("field"))));
+                    params.add(new Parameter(new Name("arg2")));
+                    params.get(1).setType(new Type("double"));
+                    params.get(1).addProperty(new Union());
+                    params.get(1).addProperty(new Subsets(new OneIdentifier("arg")));
+                    params.get(1).addProperty(new Unique());
+                    params.add(new Parameter(new Name("arg3")));
+                    params.get(2).setType(new Type("bool"));
+                    params.get(2).addProperty(new Unique());
+                    params.get(2).addProperty(new Ordered());
+                    params.get(2).addProperty(new Redefines(new Binomial(".",
+                            new Binomial(".",
+                                    new Binomial(".",
+                                            new MethodCall("method", new OneIdentifier("arg1")),
+                                            new MethodCall("forMethod",
+                                                    new Binomial("/",
+                                                            new Binomial("*",
+                                                                    new ExpressionWithParen(
+                                                                            new Binomial("+",
+                                                                                    new OneIdentifier("upperBase"),
+                                                                                    new OneIdentifier("lowerBase"))),
+                                                                    new OneIdentifier("height")),
+                                                            new OneIdentifier(2)))),
+                                    new MethodCall("ofMethod", new OneIdentifier("arg3"))),
+                            new MethodCall("inMethod", new OneIdentifier("arg4")))));
+                    params.get(2).addProperty(new Subsets(new Binomial("*",
+                            new ExpressionWithParen(
+                                    new Binomial("+",
+                                            new OneIdentifier("instance"),
+                                            new Binomial(".",
+                                                    new MethodCall("methods", new OneIdentifier("with"), new OneIdentifier("arg")),
+                                                    new MethodCall("method",
+                                                            new OneIdentifier("1.0"),
+                                                            new Monomial("-", new OneIdentifier("2.0")),
+                                                            new Monomial("+", new OneIdentifier("3.0")),
+                                                            new MethodCall("forMethod",
+                                                                    new MethodCall("ofMethod",
+                                                                            new MethodCall("inMethod", new OneIdentifier(0)))))))),
+                            new OneIdentifier("300000"))));
+                    params.get(2).addProperty(new Union());
+                    params.get(2).addProperty(new ReadOnly());
+                    expected.setParameters(params);
+
+                    obj.parse("setNumber(arg1 : int32 {redefines Class.field}, arg2 : double {union, subsets arg, unique}, arg3 : bool {unique, ordered, redefines method(arg1).forMethod((upperBase + lowerBase) * height / 2).ofMethod(arg3).inMethod(arg4), subsets (instance + methods(with, arg).method(1.0, -2.0, +3.0, forMethod(ofMethod(inMethod(0))))) * 300000, union, readOnly})");
+                    Operation actual = obj.carve();
+
+                    assertThat(actual).hasToString(expected.toString());
+                }
+            }
+        }
+
+        @Nested
+        class 名前とプロパティの場合 {
+
+            @BeforeEach
+            void setup() {
+                obj = new OperationSculptor();
+            }
+
+            @Test
+            void プロパティが1つのインスタンスを返す() {
+                Operation expected = new Operation(new Name("getNumber"));
+                expected.addProperty(new Redefines(new OneIdentifier("getNumber")));
+
+                obj.parse("getNumber() {redefines getNumber}");
+                Operation actual = obj.carve();
+
+                assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);
+            }
+
+            @Test
+            void プロパティが4つのインスタンスを返す() {
+                Operation expected = new Operation(new Name("getNumber"));
+                expected.addProperty(new Redefines(new Binomial(".",
+                        new OneIdentifier("Classes"),
+                        new MethodCall("method"))));
+                expected.addProperty(new Query());
+                expected.addProperty(new Ordered());
+                expected.addProperty(new Unique());
+
+                obj.parse("getNumber() {redefines Classes.method(), query, ordered, unique}");
+                Operation actual = obj.carve();
+
+                assertThat(actual).isEqualToComparingFieldByFieldRecursively(expected);
+            }
+        }
+    }
+
+    @Nested
+    class 不正な操作文の場合 {
+
+        @BeforeEach
+        void setup() {
+            obj = new OperationSculptor();
+        }
+
+        @Test
+        void 空文字をパースしようとすると例外を投げる() {
+            assertThatThrownBy(() -> obj.parse("")).isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        void nullをパースしようとすると例外を投げる() {
+            assertThatThrownBy(() -> obj.parse(null)).isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        void パースする前にコンテキストを取得しようとすると例外を投げる() {
+            assertThatThrownBy(() -> obj.getContext()).isInstanceOf(IllegalStateException.class);
+        }
+    }
+}


### PR DESCRIPTION
- OperationEvaluationクラスの作成
    - ほぼAttributeEvaluationクラスのコピペ
    - `AttributeEvaluation#confirmExtractingName()` メソッドについては次の理由により除去
        - コピペをOperationEvaluationクラス用に書換えた程度では、構文解析機がパラメータの`()`を名前として判断するなどにより、例外を投げる処理を行わなかった
        - 必要性がそもそも感じられなかった
- OperationSculptorクラスの作成
    - ほぼAttributeEvaluationクラスのコピペ
    - `OperationSculptor#extractOperationProperties(ClassFeatureParser.OperPropertiesContext)`メソッドはオリジナル
- usageパッケージの非推奨化
- リリース版としてバージョン1.0.0を作成
    - README.mdファイルの修正
    - build.gradleファイルのバージョン番号の修正

.gitignoreファイルで今まで無視していたparserパッケージを追加しようと思いましたが、差分が煩雑になりそうだったのでやっぱりやめました